### PR TITLE
feat: Adding python support for 106

### DIFF
--- a/lua/refactoring/config.lua
+++ b/lua/refactoring/config.lua
@@ -9,6 +9,9 @@ local config = {
         go = {
             -- cmd = [[ !gofmt -w % ]],
         },
+        python = {
+            -- TODO: add python formatting command
+        },
     },
     code_generation = {
         typescript = {
@@ -86,6 +89,33 @@ func %s(%s) {
                     ),
                     call = string.format(
                         "%s := %s(%s)",
+                        opts.ret,
+                        opts.name,
+                        table.concat(opts.args, ", ")
+                    ),
+                }
+            end,
+        },
+        python = {
+            extract_function = function(opts)
+                return {
+                    create = string.format(
+                        [[
+def %s(%s):
+    %s
+    return %s
+
+
+]],
+                        opts.name,
+                        table.concat(opts.args, ", "),
+                        type(opts.body) == "table"
+                                  and table.concat(opts.body, "\n")
+                              or opts.body,
+                        opts.ret
+                    ),
+                    call = string.format(
+                        "%s = %s(%s)",
                         opts.ret,
                         opts.name,
                         table.concat(opts.args, ", ")

--- a/lua/refactoring/region.lua
+++ b/lua/refactoring/region.lua
@@ -72,7 +72,9 @@ end
 
 --- Convert a region to a tree sitter region
 function Region:to_ts()
-    return self.start_row - 1, self.start_col, self.end_row - 1, self.end_col
+    -- Need the -2 for end_col to be  correct for `ts_utils.is_in_node_range`
+    -- function results when checking scope for languages like python
+    return self.start_row - 1, self.start_col, self.end_row - 1, self.end_col - 2
 end
 
 function Region:get_text(bufnr)

--- a/lua/refactoring/tests/extract.simple-function.expected.py
+++ b/lua/refactoring/tests/extract.simple-function.expected.py
@@ -1,0 +1,12 @@
+
+def foo_bar(a, test, test_other):
+        for x in range(test_other + test):
+        print(x, a)
+    return fill_me
+
+
+def simple_function(a):
+    test = 1
+    test_other = 11
+
+fill_me = foo_bar(a, test, test_other)

--- a/lua/refactoring/tests/extract.simple-function.py.commands
+++ b/lua/refactoring/tests/extract.simple-function.py.commands
@@ -1,0 +1,2 @@
+:4
+:execute "norm! Vj\<Esc>"

--- a/lua/refactoring/tests/extract.simple-function.start.py
+++ b/lua/refactoring/tests/extract.simple-function.start.py
@@ -1,0 +1,5 @@
+def simple_function(a):
+    test = 1
+    test_other = 11
+    for x in range(test_other + test):
+        print(x, a)

--- a/lua/refactoring/tests/refactor_spec.lua
+++ b/lua/refactoring/tests/refactor_spec.lua
@@ -38,6 +38,7 @@ local extension_to_filetype = {
     ["lua"] = "lua",
     ["ts"] = "typescript",
     ["go"] = "go",
+    ["py"] = "python",
 }
 
 local function for_each_file(cb)

--- a/queries/python/refactoring.scm
+++ b/queries/python/refactoring.scm
@@ -1,0 +1,15 @@
+;; Grabs all the local variable declarations.  This is useful for scope
+;; variable passing.  Which variables do we need to pass to the extracted
+;; function?
+((expression_statement
+  (assignment
+    (identifier) @definition.local_var)))
+
+;; grabs all the arguments that are passed into the function.  Needed for
+;; function extraction, 106
+((function_definition
+  (parameters
+    (identifier)@definition.function_argument)))
+
+;; Scope
+(function_definition) @definition.scope


### PR DESCRIPTION
Adding python support for extract function. Had to change `end_col` for `to_ts` for `Region` Class so that scope was correct for python. This is mentioned in a comment at the top of `Region` class. Appears to not have broken tests for region that exist, let me know if you want to update to something else. 