### PR TITLE
Readme: add popup.nvim as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ use {
     "ThePrimeagen/refactoring.nvim",
     requires = {
         {"nvim-lua/plenary.nvim"},
-        {"nvim-treesitter/nvim-treesitter"}
+        {"nvim-treesitter/nvim-treesitter"},
+        {"nvim-lua/popup.nvim"}
     }
 }
 ```


### PR DESCRIPTION
Improves the `README.md` files. `popup.nvim` dependency is required to be installed to run this.

Outcome of #32 