### PR TITLE
Updating minimal.vim for makefile testing

### DIFF
--- a/lua/refactoring/tests/minimal.vim
+++ b/lua/refactoring/tests/minimal.vim
@@ -1,4 +1,18 @@
 set rtp+=.
 set rtp+=../plenary.nvim
+set rtp+=../nvim-treesitter
 
 runtime! plugin/plenary.vim
+runtime! plugin/nvim-treesitter
+runtime! plugin/refactoring.nvim
+
+lua <<EOF
+require'nvim-treesitter.configs'.setup{
+  ensure_installed = {
+    'go',
+    'lua',
+    'python',
+    'typescript',
+  },
+}
+EOF

--- a/lua/refactoring/tests/minimal.vim
+++ b/lua/refactoring/tests/minimal.vim
@@ -1,7 +1,10 @@
 set rtp+=.
 set rtp+=../plenary.nvim
 set rtp+=../nvim-treesitter
+set rtp+=../popup.nvim/
 
+
+runtime! plugin/popup.nvim/
 runtime! plugin/plenary.vim
 runtime! plugin/nvim-treesitter
 runtime! plugin/refactoring.nvim


### PR DESCRIPTION
Noticed on stream that `makefile test` was not working for you because of missing dependencies (probably others as well). Added plugin dependencies to `minimal.vim` file to resolve. Please run on your machine to let me know if this is now working, however this was working for me before these changes. That may be because of my nvim configuration though, but I'm not sure why. If this still fails for you I'll have to keep looking into this. 