### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+    lint:
+        name: PlenaryBustedDirectory
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                path: refactoring.nvim
+            - uses: actions/checkout@v2
+              with:
+                repository: nvim-treesitter/nvim-treesitter
+                path: nvim-treesitter
+            - uses: actions/checkout@v2
+              with:
+                repository: nvim-lua/plenary.nvim
+                path: plenary.nvim
+            - name: Setup
+              run: |
+                  sudo apt-get update
+                  sudo add-apt-repository ppa:neovim-ppa/unstable
+                  sudo apt-get install neovim
+            - name: Test
+              run:
+                cd refactoring.nvim && make test

--- a/lua/refactoring/tests/minimal.vim
+++ b/lua/refactoring/tests/minimal.vim
@@ -23,12 +23,16 @@ set shiftwidth=4
 runtime! plugin/plenary.vim
 
 lua <<EOF
-require'nvim-treesitter.configs'.setup{
-  ensure_installed = {
-    'go',
-    'lua',
-    'python',
-    'typescript',
-  },
-}
+local required_parsers = {'go', 'lua', 'python', 'typescript'}
+local installed_parsers = require'nvim-treesitter.info'.installed_parsers()
+local to_install = vim.tbl_filter(function(parser)
+  return not vim.tbl_contains(installed_parsers, parser)
+end, required_parsers)
+if #to_install > 0 then
+  -- fixes 'pos_delta >= 0' error - https://github.com/nvim-lua/plenary.nvim/issues/52
+  vim.cmd('set display=lastline')
+  -- make "TSInstall*" available
+  vim.cmd 'runtime! plugin/nvim-treesitter.vim'
+  vim.cmd('TSInstallSync ' .. table.concat(to_install, ' '))
+end
 EOF


### PR DESCRIPTION
From what I gather "ensure_installed" does an async install, which makes tests run before the parsers are available. This works around that by using `TSInstallSync`.

Parser diffing happens, so that you're not prompted to reinstall a parser that's already available.

Additionally, I've hit a [bug in nvim/plenary](https://github.com/nvim-lua/plenary.nvim/issues/52), where output produced by `TSInstall*` kabooms the test run:
```
nvim: /build/neovim-0bOHCD/neovim-0.5.0+ubuntu2+git202108111755-7d2233fad-d569569c9/src/nvim/message.c:2284: msg_scroll_flush: Assertion `pos_delta >= 0' failed.
```

It perhaps lacks the coconut oiliness, but seems to work, so.. 🤷.