### PR TITLE
Add lunarvim to rtp in order to run tests locally

### DIFF
--- a/lua/refactoring/tests/minimal.vim
+++ b/lua/refactoring/tests/minimal.vim
@@ -14,6 +14,10 @@ set rtp+=~/.vim/plugged/nvim-treesitter
 set rtp+=~/.local/share/nvim/site/pack/packer/start/plenary.nvim
 set rtp+=~/.local/share/nvim/site/pack/packer/start/nvim-treesitter
 
+" If you are using lunarvim
+set rtp+=~/.local/share/lunarvim/site/pack/packer/start/plenary.nvim
+set rtp+=~/.local/share/lunarvim/site/pack/packer/start/nvim-treesitter
+
 set autoindent
 set smartindent
 set tabstop=4


### PR DESCRIPTION
If someone uses lunarvim for local development the packer directory is located in a different directory. This allows to run the tests with the local configuration, without the need to check out plenary and nvim-treesitter locally.