### PR TITLE
feat: POC of formatting input in python

### DIFF
--- a/lua/refactoring/code_generation/python.lua
+++ b/lua/refactoring/code_generation/python.lua
@@ -1,8 +1,26 @@
 local utils = require("refactoring.code_generation.utils")
 
+local function get_prefix(start_col)
+    local temp = {}
+    for i = 1, start_col do
+        temp[i] = " "
+    end
+    return table.concat(temp)
+end
+
+local function combine_strings(a, b)
+    local temp = {}
+    temp[1] = a
+    temp[2] = b
+    return table.concat(temp)
+end
+
 local python = {
     constant = function(opts)
-        return string.format("%s = %s\n", opts.name, opts.value)
+        return combine_strings(
+            get_prefix(opts.start_col),
+            string.format("%s = %s\n", opts.name, opts.value)
+        )
     end,
     ["return"] = function(code)
         return string.format("return %s", utils.stringify_code(code))

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -84,6 +84,11 @@ M.extract_to_file = function(bufnr)
                 body = function_body,
             })
 
+            local extract_node = refactor.root:named_descendant_for_range(
+                refactor.region:to_ts()
+            )
+
+            local _, start_col, _, _ = extract_node:range()
             refactor.text_edits = {
                 {
                     region = utils.get_top_of_file_region(refactor.scope),
@@ -98,6 +103,7 @@ M.extract_to_file = function(bufnr)
                             name = function_name,
                             args = args,
                         }),
+                        start_col = start_col,
                     }),
                 },
             }
@@ -129,6 +135,10 @@ M.extract = function(bufnr)
                 body = function_body,
             })
 
+            local extract_node = refactor.root:named_descendant_for_range(
+                refactor.region:to_ts()
+            )
+            local _, start_col, _, _ = extract_node:range()
             refactor.text_edits = {
                 {
                     region = utils.region_above_node(refactor.scope),
@@ -143,6 +153,7 @@ M.extract = function(bufnr)
                             name = function_name,
                             args = args,
                         }),
+                        start_col = start_col,
                     }),
                 },
             }

--- a/lua/refactoring/tests/minimal.vim
+++ b/lua/refactoring/tests/minimal.vim
@@ -23,6 +23,7 @@ set smartindent
 set tabstop=4
 set expandtab
 set shiftwidth=4
+set noswapfile
 
 runtime! plugin/plenary.vim
 

--- a/lua/refactoring/tests/refactor/106/py/simple-function/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/simple-function/extract.expected.py
@@ -9,5 +9,5 @@ def simple_function(a):
     test = 1
     test_other = 11
 
-fill_me = foo_bar(a, test, test_other)
+    fill_me = foo_bar(a, test, test_other)
 


### PR DESCRIPTION
POC of formatting with start col of first node in highlighted scope. Let me know if this works and we can add for languages where spaces are used by default (like python). For languages like golang, `gofmt` should take care of a lot of these issues. 