### PR TITLE
feat: Add make commands for building/running docker test container wi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:latest
+
+# Make code directory
+RUN mkdir -p code/refactoring.nvim
+
+# update, software-properties-common, git
+RUN apt-get update && \
+    apt install -y software-properties-common && \
+    apt install -y git
+
+# Clone dependencies
+RUN git clone https://github.com/neovim/nvim-lspconfig.git /code/nvim-lspconfig
+RUN git clone https://github.com/nvim-treesitter/nvim-treesitter.git /code/nvim-treesitter
+RUN git clone https://github.com/nvim-lua/plenary.nvim.git /code/plenary.nvim
+
+# Install latest neovim, nodejs, npm, typescript + language server
+RUN add-apt-repository --yes ppa:neovim-ppa/unstable && \
+    apt-get install -y neovim && \
+    apt install -y nodejs npm && \
+    npm install -g typescript typescript-language-server
+
+# Run tests when run container
+CMD cd /code/refactoring.nvim && make test
+

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,9 @@ lint:
 
 pr-ready: fmt test lint
 
+docker-build:
+	docker build --no-cache . -t refactoring
+
+docker-test:
+	docker run -v $(shell pwd):/code/refactoring.nvim -t refactoring
+


### PR DESCRIPTION
feat: Add make commands for building/running docker test container with current refactoring branch

`make docker-build` builds ubuntu container with latest neovim and clones dependencies
`make docker-test` mounts `refactoring.nvim` directory and runs tests with forcing to install everything in `minimal.vim`

This doesn't recreate github workflow issue with lsp-tests ([this PR for breadcrumbs](https://github.com/ThePrimeagen/refactoring.nvim/pull/84)), but thought it be worth to get a PR up for this separately to make it easier for others to contribute with running tests locally. 