### PR TITLE
chore: Adding tests for inline var for typescript

### DIFF
--- a/lua/refactoring/tests/lsp_utils_spec.lua
+++ b/lua/refactoring/tests/lsp_utils_spec.lua
@@ -14,12 +14,8 @@ end
 
 describe("lsp_utils", function()
     it("should get the references and definition of cursor", function()
-        vim.cmd(":e ./lua/refactoring/tests/lsp_utils_test_file.ts")
-        local bufnr = vim.api.nvim_get_current_buf()
-        vim.cmd(":LspStart")
-        vim.wait(10000, function()
-            return #vim.lsp.buf_get_clients(bufnr) > 0
-        end)
+        local bufnr = test_utils.open_test_file("lsp_utils_test_file.ts")
+        test_utils.start_lsp(bufnr)
 
         assert.are.same(#vim.lsp.buf_get_clients(bufnr), 1)
         assert.are.same(vim.lsp.buf_is_attached(bufnr, 1), true)

--- a/lua/refactoring/tests/refactor/123/ts/example/inline_var.commands
+++ b/lua/refactoring/tests/refactor/123/ts/example/inline_var.commands
@@ -1,0 +1,1 @@
+:execute "norm! 9j2wvE\<Esc>"

--- a/lua/refactoring/tests/refactor/123/ts/example/inline_var.expected.ts
+++ b/lua/refactoring/tests/refactor/123/ts/example/inline_var.expected.ts
@@ -1,0 +1,13 @@
+type Order = {
+    quantity: number;
+    itemPrice: number;
+}
+
+// This the straight from the book (slight modifications)
+function orderCalculation(order: Order) {
+
+    order.quantity*order.itemPrice;
+    return order.quantity*order.itemPrice -
+        Math.max(0, order.quantity - 500) * order.itemPrice * 0.05 +
+        Math.min(order.quantity*order.itemPrice * 0.1, 100);
+}

--- a/lua/refactoring/tests/refactor/123/ts/example/inline_var.start.ts
+++ b/lua/refactoring/tests/refactor/123/ts/example/inline_var.start.ts
@@ -1,0 +1,13 @@
+type Order = {
+    quantity: number;
+    itemPrice: number;
+}
+
+// This the straight from the book (slight modifications)
+function orderCalculation(order: Order) {
+    const basePrice = order.quantity*order.itemPrice;
+    basePrice;
+    return basePrice -
+        Math.max(0, order.quantity - 500) * order.itemPrice * 0.05 +
+        Math.min(basePrice * 0.1, 100);
+}

--- a/lua/refactoring/tests/utils.lua
+++ b/lua/refactoring/tests/utils.lua
@@ -51,4 +51,16 @@ function M.get_definition_under_cursor(bufnr)
     return definition
 end
 
+function M.open_test_file(file)
+    vim.cmd(":e  ./lua/refactoring/tests/" .. file)
+    return vim.api.nvim_get_current_buf()
+end
+
+function M.start_lsp(bufnr)
+    vim.cmd(":LspStart")
+    vim.wait(10000, function()
+        return #vim.lsp.buf_get_clients(bufnr) > 0
+    end)
+end
+
 return M


### PR DESCRIPTION
Adding tests for inline var for typescript. Had to edit some logic about finding test files and separately those that require lsp and those that don't, this should be edited later to not be as hacky as how I wrote here. But for now this starts the ability to add `inline_var` tests. 