### PR TITLE
Use vim.ui.input instead of vim.fn.input

### DIFF
--- a/lua/refactoring/get_input.lua
+++ b/lua/refactoring/get_input.lua
@@ -2,6 +2,15 @@ local Config = require("refactoring.config")
 
 -- This will be able to be hot swapped out with better input capture as we
 -- go on.  This is just a place holder
+local async = require("plenary.async")
+-- local input = vim.fn.input
+local input = async.wrap(function(prompt, text, completion, callback)
+    vim.ui.input({
+        prompt = prompt,
+        default = text,
+        completion = completion,
+    }, callback)
+end, 4)
 local function get_input(question, text)
     text = text or ""
 
@@ -15,7 +24,7 @@ local function get_input(question, text)
         end
     end
 
-    return vim.fn.input(question, text)
+    return input(question, text, nil)
 end
 
 return get_input


### PR DESCRIPTION
This is a draft PR, needs some architectural changes to `Pipeline` due to the new api of `vim.ui.input`
