### PR TITLE
fix: remove catching out of bounds error for cursor position on apply…

### DIFF
--- a/lua/refactoring/tasks/apply_text_edits.lua
+++ b/lua/refactoring/tasks/apply_text_edits.lua
@@ -34,20 +34,7 @@ local function refactor_apply_text_edits(refactor)
     end
 
     for bufnr, edit_set in pairs(edits) do
-        local status, retval = pcall(
-            vim.lsp.util.apply_text_edits,
-            edit_set,
-            bufnr
-        )
-
-        if status == false then
-            -- HACK:: Figure out why this started failing for cursor position
-            -- print ("Return Value: ", retval)
-            -- If not the expected error, throw it
-            if not string.match(retval, "Cursor position outside buffer") then
-                error(retval)
-            end
-        end
+        vim.lsp.util.apply_text_edits(edit_set, bufnr)
     end
 
     return true, refactor


### PR DESCRIPTION
fix: remove catching out of bounds error for cursor position on apply text edits

#102 