### PR TITLE
fix: handle setup call with no args

### DIFF
--- a/lua/refactoring/config/init.lua
+++ b/lua/refactoring/config/init.lua
@@ -100,6 +100,7 @@ function M.get()
 end
 
 function M.setup(c)
+    c = c or {}
     config = Config:new(c)
 end
 


### PR DESCRIPTION
#140 

Enable calling `require('refactoring').setup()` without any args and prevent a `vim.tbl_deep_extend` with a `nil` value.