### PR TITLE
chore(dev): added inline code to find parent nodes of current node

### DIFF
--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -102,6 +102,10 @@ local function containing_node_by_type(node, container_map)
             break
         end
         node = node:parent()
+    -- This statement can be uncommented to print all the parent nodes of the
+    -- current node until there are no more. Useful in finding certain nodes
+    -- like the global scope node, which doesn't show up in playground.
+    -- print(node:type())
     until node == nil
 
     return node


### PR DESCRIPTION
This one line of code can be uncommented to find the parent nodes of a given selected node. This is especially useful in finding the top level node (for the global scope of a language), which doesn't show up in Playground. This would've been really useful for me in doing #166 and saved me hours, because I couldn't find the global node in the Playground or in any of the limited documentation for the C++ TS parser.