### PR TITLE
fix(inline-var-cursor): added error message when not on identifier

### DIFF
--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -43,6 +43,10 @@ function M.inline_var(bufnr, opts)
 
             local value_text = ts.get_node_text(value_node, bufnr)
 
+            if current_node:type() ~= "identifier" then
+                error("Error: node under cursor is not an identifier")
+            end
+
             for _, ref in pairs(references) do
                 -- TODO: In my mind, if nothing is left on the line when you remove, it should get deleted.
                 -- Could be done via opts into replace_text.


### PR DESCRIPTION
Right now, inline var is only designed to work when the cursor is on the identifier. If the cursor is not on an identifier, it actually does not error out, but instead produces a weird result. This PR adds an error message when the cursor is not on an identifier to prevent this from happening. This is more of a temporary fix; in the future I think we should try and make it so that it finds the identifier if a declaration is selected (that might take some more time).