### PR TITLE
feat(c-cpp-func-args-types): added func arg types for c/cpp

### DIFF
--- a/lua/refactoring/code_generation/cpp.lua
+++ b/lua/refactoring/code_generation/cpp.lua
@@ -1,5 +1,13 @@
 local code_utils = require("refactoring.code_generation.utils")
 
+local function cpp_func_args(args)
+    local new_args = {}
+    for _, arg in ipairs(args) do
+        table.insert(new_args, string.format("INSERT_VAR_TYPE %s", arg))
+    end
+    return new_args
+end
+
 local cpp = {
     comment = function(statement)
         return string.format("// %s", statement)
@@ -19,7 +27,7 @@ void %s(%s) {
 
 ]],
             opts.name,
-            table.concat(opts.args, ", "),
+            table.concat(cpp_func_args(opts.args), ", "),
             code_utils.stringify_code(opts.body)
         )
     end,

--- a/lua/refactoring/tests/refactor/106/c/simple-function/extract.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/simple-function/extract.expected.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-void foo_bar(a, test, test_other) {
+void foo_bar(INSERT_VAR_TYPE a, INSERT_VAR_TYPE test, INSERT_VAR_TYPE test_other) {
       for (int idx = test - 1; idx < test_other; idx++) {
     printf("%d %d", idx, a);
   }

--- a/lua/refactoring/tests/refactor/106/cpp/class-function/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/class-function/extract.expected.cpp
@@ -2,7 +2,7 @@
 
 class Coconut {
 
-void foo(a, test, test_other) {
+void foo(INSERT_VAR_TYPE a, INSERT_VAR_TYPE test, INSERT_VAR_TYPE test_other) {
         for (int x = 0; x < test_other + test; x++) {
       std::cout << x << " " << a << std::endl;
     }

--- a/lua/refactoring/tests/refactor/106/cpp/simple-function/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/simple-function/extract.expected.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-void foo_bar(a, test, test_other) {
+void foo_bar(INSERT_VAR_TYPE a, INSERT_VAR_TYPE test, INSERT_VAR_TYPE test_other) {
       for (int idx = test - 1; idx < test_other; idx++) {
     std::cout << idx << " " << a << std::endl;
   }


### PR DESCRIPTION
This PR replicates #171 (what was done for the golang function args) for C/C++ as well.