### PR TITLE
feat(cpp-use-auto): separated cpp and c code generations when type in…

### DIFF
--- a/lua/refactoring/code_generation/c.lua
+++ b/lua/refactoring/code_generation/c.lua
@@ -1,3 +1,35 @@
--- c = cpp
+-- c mostly == cpp
+local code_utils = require("refactoring.code_generation.utils")
 local cpp = require("refactoring.code_generation.cpp")
-return cpp
+
+local c = {
+    comment = cpp.comment,
+    print = cpp.print,
+    ["return"] = cpp["return"],
+    ["function"] = cpp["function"],
+    function_return = function(opts)
+        return string.format(
+            [[
+INPUT_RETURN_TYPE %s(%s) {
+    %s
+}
+
+]],
+            opts.name,
+            table.concat(opts.args, ", "),
+            code_utils.stringify_code(opts.body)
+        )
+    end,
+    constant = function(opts)
+        return string.format(
+            "INSERT_TYPE_HERE %s = %s;\n",
+            opts.name,
+            opts.value
+        )
+    end,
+    call_function = cpp.call_function,
+    pack = cpp.pack,
+    terminate = cpp.terminate,
+}
+
+return c

--- a/lua/refactoring/code_generation/cpp.lua
+++ b/lua/refactoring/code_generation/cpp.lua
@@ -26,7 +26,7 @@ void %s(%s) {
     function_return = function(opts)
         return string.format(
             [[
-INPUT_RETURN_TYPE %s(%s) {
+auto %s(%s) {
     %s
 }
 
@@ -37,11 +37,7 @@ INPUT_RETURN_TYPE %s(%s) {
         )
     end,
     constant = function(opts)
-        return string.format(
-            "INSERT_TYPE_HERE %s = %s;\n",
-            opts.name,
-            opts.value
-        )
+        return string.format("auto %s = %s;\n", opts.name, opts.value)
     end,
     call_function = function(opts)
         return string.format("%s(%s)", opts.name, table.concat(opts.args, ", "))

--- a/lua/refactoring/tests/refactor/119/cpp/example/extract_var.expected.cpp
+++ b/lua/refactoring/tests/refactor/119/cpp/example/extract_var.expected.cpp
@@ -8,7 +8,7 @@ struct Order {
 
 double orderCalculation(Order order, int a, int b) {
   float temp = a * b;
-INSERT_TYPE_HERE basePrice = order.quantity*order.itemPrice;
+auto basePrice = order.quantity*order.itemPrice;
  float blah = (basePrice) - 7;
 
   std::cout << temp << " " << blah << std::endl;


### PR DESCRIPTION
After the discussion in #98 with @pranavrao145, I added separate code gens for C and C++, which requires type info, as C++ has `auto`.

I think it should be extended and merged after #185, as C++ also supports `auto` for function parameters. Another choice, even better, in my opinion, is to have types extracted by LSP for function params.