### PR TITLE
docs(README): fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ you can do so use using the **Telescope extension.** Here is an example config
 for this setup:
 
 ```lua
--- Remap to open the Telescope refactoring menu in visual mode
+-- load refactoring Telescope extension
 require("telescope").load_extension("refactoring")
 
 -- remap to open the Telescope refactoring menu in visual mode


### PR DESCRIPTION
Just something I noticed while scrolling - there was an accidental duplicate comment in the README examples. Fixed now.