### PR TITLE
fix(lsp-utils): fix lsp_utils in accordance with latest nvim breaking changes

### DIFF
--- a/lua/refactoring/tasks/apply_text_edits.lua
+++ b/lua/refactoring/tasks/apply_text_edits.lua
@@ -34,7 +34,7 @@ local function refactor_apply_text_edits(refactor)
     end
 
     for bufnr, edit_set in pairs(edits) do
-        vim.lsp.util.apply_text_edits(edit_set, bufnr)
+        vim.lsp.util.apply_text_edits(edit_set, bufnr, "utf-16")
     end
 
     return true, refactor

--- a/lua/refactoring/tests/lsp_utils_spec.lua
+++ b/lua/refactoring/tests/lsp_utils_spec.lua
@@ -40,7 +40,7 @@ describe("lsp_utils", function()
         local region = Region:from_current_selection()
         local delete_text = lsp_utils.delete_text(region)
         local bufnr = vim.api.nvim_get_current_buf()
-        vim.lsp.util.apply_text_edits({ delete_text }, bufnr)
+        vim.lsp.util.apply_text_edits({ delete_text }, bufnr, "utf-16")
         assert.are.same({
             "foo",
             "if (true) {",
@@ -58,7 +58,7 @@ describe("lsp_utils", function()
         local region = Region:from_current_selection()
         local insert_text = lsp_utils.insert_text(region, "hello, piq")
         local bufnr = vim.api.nvim_get_current_buf()
-        vim.lsp.util.apply_text_edits({ insert_text }, bufnr)
+        vim.lsp.util.apply_text_edits({ insert_text }, bufnr, "utf-16")
         assert.are.same({
             "foo",
             "if (true) {",
@@ -80,7 +80,11 @@ bin, ban,]]
         )
 
         local bufnr = vim.api.nvim_get_current_buf()
-        vim.lsp.util.apply_text_edits({ insert_text, delete_text }, bufnr)
+        vim.lsp.util.apply_text_edits(
+            { insert_text, delete_text },
+            bufnr,
+            "utf-16"
+        )
 
         assert.are.same({
             "foo",


### PR DESCRIPTION
Fixed lsp_utils to work with the latest Neovim Nightly in accordance with the latest breaking changes in [this issue](https://github.com/neovim/neovim/issues/14090). This was previously causing all tests to fail, but all tests pass with this change.