### PR TITLE
Inline Var: Delete single declaration

### DIFF
--- a/lua/refactoring/code_generation/langs/c.lua
+++ b/lua/refactoring/code_generation/langs/c.lua
@@ -32,6 +32,34 @@ local function c_func_args(opts)
     end
 end
 
+local function c_constant(opts)
+    local constant_string_pattern
+
+    if opts.multiple then
+        constant_string_pattern = "INSERT_TYPE_HERE "
+
+        for idx, identifier in pairs(opts.identifiers) do
+            if idx == #opts.identifiers then
+                constant_string_pattern = constant_string_pattern
+                    .. string.format("%s = %s", identifier, opts.values[idx])
+            else
+                constant_string_pattern = constant_string_pattern
+                    .. string.format("%s = %s,", identifier, opts.values[idx])
+            end
+        end
+
+        constant_string_pattern = constant_string_pattern .. ";\n"
+    else
+        constant_string_pattern = string.format(
+            "INSERT_TYPE_HERE %s = %s;\n",
+            opts.name,
+            opts.value
+        )
+    end
+
+    return constant_string_pattern
+end
+
 local c = {
     comment = cpp.comment,
     print = cpp.print,
@@ -53,11 +81,7 @@ local c = {
         )
     end,
     constant = function(opts)
-        return string.format(
-            "INSERT_TYPE_HERE %s = %s;\n",
-            opts.name,
-            opts.value
-        )
+        return c_constant(opts)
     end,
     call_function = cpp.call_function,
     pack = cpp.pack,

--- a/lua/refactoring/code_generation/langs/cpp.lua
+++ b/lua/refactoring/code_generation/langs/cpp.lua
@@ -30,6 +30,34 @@ local function cpp_func_args(opts)
     end
 end
 
+local function cpp_constant(opts)
+    local constant_string_pattern
+
+    if opts.multiple then
+        constant_string_pattern = "auto "
+
+        for idx, identifier in pairs(opts.identifiers) do
+            if idx == #opts.identifiers then
+                constant_string_pattern = constant_string_pattern
+                    .. string.format("%s = %s", identifier, opts.values[idx])
+            else
+                constant_string_pattern = constant_string_pattern
+                    .. string.format("%s = %s,", identifier, opts.values[idx])
+            end
+        end
+
+        constant_string_pattern = constant_string_pattern .. ";\n"
+    else
+        constant_string_pattern = string.format(
+            "auto %s = %s;\n",
+            opts.name,
+            opts.value
+        )
+    end
+
+    return constant_string_pattern
+end
+
 local cpp = {
     comment = function(statement)
         return string.format("// %s", statement)
@@ -71,7 +99,7 @@ void %s(%s) {
         )
     end,
     constant = function(opts)
-        return string.format("auto %s = %s;\n", opts.name, opts.value)
+        return cpp_constant(opts)
     end,
     call_function = function(opts)
         return string.format("%s(%s)", opts.name, table.concat(opts.args, ", "))

--- a/lua/refactoring/code_generation/langs/go.lua
+++ b/lua/refactoring/code_generation/langs/go.lua
@@ -106,11 +106,23 @@ local function go_call_class_func(opts)
 end
 
 local function constant(opts)
-    return string.format(
-        "%s := %s\n",
-        code_utils.returnify(opts.name, string_pattern),
-        opts.value
-    )
+    local constant_string_pattern
+
+    if opts.multiple then
+        constant_string_pattern = string.format(
+            "%s := %s\n",
+            table.concat(opts.identifiers, ", "),
+            table.concat(opts.values, ", ")
+        )
+    else
+        constant_string_pattern = string.format(
+            "%s := %s\n",
+            code_utils.returnify(opts.name, string_pattern),
+            opts.value
+        )
+    end
+
+    return constant_string_pattern
 end
 
 local go = {

--- a/lua/refactoring/code_generation/langs/lua.lua
+++ b/lua/refactoring/code_generation/langs/lua.lua
@@ -14,6 +14,26 @@ end
     )
 end
 
+local function lua_constant(opts)
+    local constant_string_pattern
+
+    if opts.multiple then
+        constant_string_pattern = string.format(
+            "local %s = %s\n",
+            table.concat(opts.identifiers, ", "),
+            table.concat(opts.values, ", ")
+        )
+    else
+        constant_string_pattern = string.format(
+            "local %s = %s\n",
+            opts.name,
+            opts.value
+        )
+    end
+
+    return constant_string_pattern
+end
+
 local lua = {
     comment = function(statement)
         return string.format("-- %s", statement)
@@ -25,7 +45,7 @@ local lua = {
         return string.format('print("%s", vim.inspect(%s))', prefix, var)
     end,
     constant = function(opts)
-        return string.format("local %s = %s\n", opts.name, opts.value)
+        return lua_constant(opts)
     end,
     ["function"] = function(opts)
         return lua_function(opts)

--- a/lua/refactoring/code_generation/langs/python.lua
+++ b/lua/refactoring/code_generation/langs/python.lua
@@ -28,9 +28,29 @@ def %s(self, %s):
     )
 end
 
+local function python_constant(opts)
+    local constant_string_pattern
+
+    if opts.multiple then
+        constant_string_pattern = string.format(
+            "%s = %s\n",
+            table.concat(opts.identifiers, ", "),
+            table.concat(opts.values, ", ")
+        )
+    else
+        constant_string_pattern = string.format(
+            "%s = %s\n",
+            opts.name,
+            opts.value
+        )
+    end
+
+    return constant_string_pattern
+end
+
 local python = {
     constant = function(opts)
-        return string.format("%s = %s\n", opts.name, opts.value)
+        return python_constant(opts)
     end,
     ["return"] = function(code)
         return string.format("return %s", code_utils.stringify_code(code))

--- a/lua/refactoring/code_generation/langs/typescript.lua
+++ b/lua/refactoring/code_generation/langs/typescript.lua
@@ -16,6 +16,34 @@ function %s(%s) {
     )
 end
 
+local function typescript_constant(opts)
+    local constant_string_pattern
+
+    if opts.multiple then
+        constant_string_pattern = "const "
+
+        for idx, identifier in pairs(opts.identifiers) do
+            if idx == #opts.identifiers then
+                constant_string_pattern = constant_string_pattern
+                    .. string.format("%s = %s", identifier, opts.values[idx])
+            else
+                constant_string_pattern = constant_string_pattern
+                    .. string.format("%s = %s,", identifier, opts.values[idx])
+            end
+        end
+
+        constant_string_pattern = constant_string_pattern .. ";\n"
+    else
+        constant_string_pattern = string.format(
+            "const %s = %s;\n",
+            code_utils.returnify(opts.name, string_pattern),
+            opts.value
+        )
+    end
+
+    return constant_string_pattern
+end
+
 local typescript = {
     print = function(statement)
         return string.format('console.log("%s");', statement)
@@ -28,11 +56,7 @@ local typescript = {
     end,
     -- The constant can be destructured
     constant = function(opts)
-        return string.format(
-            "const %s = %s;\n",
-            code_utils.returnify(opts.name, string_pattern),
-            opts.value
-        )
+        return typescript_constant(opts)
     end,
 
     -- This is for returing multiple arguments from a function

--- a/lua/refactoring/tests/refactor/123/c/multiple-vars/inline_var.expected.c
+++ b/lua/refactoring/tests/refactor/123/c/multiple-vars/inline_var.expected.c
@@ -18,7 +18,8 @@ struct Order {
 };
 
 float orderCalculation(struct Order order) {
-  float basePrice = order.quantity * order.itemPrice, i = 3;
+  INSERT_TYPE_HERE i = 3;
+
   return order.quantity * order.itemPrice - max(0, order.quantity - 500) * order.itemPrice * 0.05 +
          min(order.quantity * order.itemPrice * 0.1, 100.0);
 }

--- a/lua/refactoring/tests/refactor/123/cpp/multiple-vars/inline_var.expected.cpp
+++ b/lua/refactoring/tests/refactor/123/cpp/multiple-vars/inline_var.expected.cpp
@@ -6,7 +6,8 @@ struct Order {
 };
 
 float orderCalculation(Order order) {
-  float basePrice = order.quantity * order.itemPrice, i = 3;
+  auto i = 3;
+
   return order.quantity * order.itemPrice -
          std::max(0, order.quantity - 500) * order.itemPrice * 0.05 +
          std::min(order.quantity * order.itemPrice * 0.1, 100.0);

--- a/lua/refactoring/tests/refactor/123/go/multiple-vars/inline_var.expected.go
+++ b/lua/refactoring/tests/refactor/123/go/multiple-vars/inline_var.expected.go
@@ -8,6 +8,7 @@ type Order struct {
 }
 
 func orderCalculation(order Order) float64 {
-	basePrice, i := order.quantity*order.itemPrice, 3
-	return order.quantity*order.itemPrice, 3 - math.Max(0, order.quantity-500)*order.itemPrice*0.05 + math.Min(order.quantity*order.itemPrice, 3*0.1, 100.0)
+	i := 3
+
+	return order.quantity*order.itemPrice - math.Max(0, order.quantity-500)*order.itemPrice*0.05 + math.Min(order.quantity*order.itemPrice*0.1, 100.0)
 }

--- a/lua/refactoring/tests/refactor/123/js/multiple-vars/inline_var.expected.js
+++ b/lua/refactoring/tests/refactor/123/js/multiple-vars/inline_var.expected.js
@@ -1,6 +1,7 @@
 // This the straight from the book (slight modifications)
 function orderCalculation(order) {
-    const basePrice = order.quantity * order.itemPrice, i = 3;
+    const i = 3;
+
     order.quantity * order.itemPrice;
     return (
         order.quantity * order.itemPrice -

--- a/lua/refactoring/tests/refactor/123/lua/multiple-vars/inline_var.expected.lua
+++ b/lua/refactoring/tests/refactor/123/lua/multiple-vars/inline_var.expected.lua
@@ -1,7 +1,8 @@
 -- stylua: ignore start
 
 local function orderCalculation(order)
-    local basePrice, i = order.quantity * order.itemPrice, 3
+    local i = 3
+
     return order.quantity * order.itemPrice
         - math.max(0, order.quantity - 500) * order.itemPrice * 0.05
         + math.min(order.quantity * order.itemPrice * 0.1, 100)

--- a/lua/refactoring/tests/refactor/123/ts/multiple-vars/inline_var.expected.ts
+++ b/lua/refactoring/tests/refactor/123/ts/multiple-vars/inline_var.expected.ts
@@ -5,7 +5,8 @@ type Order = {
 
 // This the straight from the book (slight modifications)
 function orderCalculation(order: Order) {
-    const basePrice = order.quantity*order.itemPrice, i = 3;
+    const i = 3;
+
     order.quantity*order.itemPrice;
     return order.quantity*order.itemPrice -
         Math.max(0, order.quantity - 500) * order.itemPrice * 0.05 +

--- a/lua/refactoring/treesitter/langs/go.lua
+++ b/lua/refactoring/treesitter/langs/go.lua
@@ -54,7 +54,7 @@ function Golang.new(bufnr, ft)
             InlineNode(
                 "(var_declaration (var_spec value: (expression_list (_) @tmp_capture)))"
             ),
-            InlineNode("(short_var_declaration right: (_) @tmp_capture)"),
+            InlineNode("(short_var_declaration right: (_ (_) @tmp_capture))"),
         },
         debug_paths = {
             function_declaration = FieldNode("name"),


### PR DESCRIPTION
# New Features
As an extension to #211, this PR will allow for the deletion of a singular variable when inlining for all supported languages. This PR closes #218.

# Limitations/Next Steps
- In C/C++, this functionality ignores the type of the variable and simply inserts the default type value for the new declaration. I intend to fix this at some point, but it is yet again far too much custom logic to put in this PR (especially because it deals with one particular filetype)
- Since Python was not supported in #211, it is not supported here either yet.
- 123 in general has become messy to a point I don't like anymore; at some point I will clean this up to look more like 106 (i.e. splitting everything up into more functions and simply calling the main function in the pipeline). 