### PR TITLE
feat(query): Return an error if no parser found

### DIFF
--- a/lua/refactoring/query.lua
+++ b/lua/refactoring/query.lua
@@ -19,6 +19,11 @@ Query.query_type = {
 
 function Query.get_root(bufnr, filetype)
     local parser = parsers.get_parser(bufnr or 0, filetype)
+    if not parser then
+        error(
+            "No treesitter parser found. Install one using :TSInstall <language>"
+        )
+    end
     return parser:parse()[1]:root()
 end
 


### PR DESCRIPTION
In cases where there are no treesitter parsers installed for the
current buffer, we can't do anything. This could happen in cases
where the user hasn't installed treesitter parser for the
specific language.

This should improve the user experience by telling them what to fix.

Issue #216
