### PR TITLE
fix(123-single-selection): fixed highlighting and inlining single declaration

### DIFF
--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -56,6 +56,7 @@ local function get_node_to_inline(identifiers, bufnr)
         error("No declarations in selected area")
     elseif #identifiers == 1 then
         identifier_pos = 1
+        node_to_inline = identifiers[identifier_pos]
     else
         node_to_inline, identifier_pos = get_select_input(
             identifiers,


### PR DESCRIPTION
It was previously not inlining the variable, but simply deleting it.