### PR TITLE
Cleanup

### DIFF
--- a/lua/refactoring/refactor/119.lua
+++ b/lua/refactoring/refactor/119.lua
@@ -10,6 +10,98 @@ local ensure_code_gen = require("refactoring.tasks.ensure_code_gen")
 
 local M = {}
 
+local function extract_var_setup(refactor)
+    local extract_node = refactor.region_node
+
+    local extract_node_text = table.concat(
+        utils.get_node_text(extract_node),
+        ""
+    )
+
+    local sexpr = extract_node:sexpr()
+    local occurrences = Query.find_occurrences(
+        refactor.scope,
+        sexpr,
+        refactor.bufnr
+    )
+
+    local actual_occurrences = {}
+    local texts = {}
+
+    for _, occurrence in pairs(occurrences) do
+        local text = table.concat(utils.get_node_text(occurrence), "")
+        if text == extract_node_text then
+            table.insert(actual_occurrences, occurrence)
+            table.insert(texts, text)
+        end
+    end
+    utils.sort_in_appearance_order(actual_occurrences)
+
+    local var_name = get_input("119: What is the var name > ")
+    assert(var_name ~= "", "Error: Must provide new var name")
+
+    refactor.text_edits = {}
+    for _, occurrence in pairs(actual_occurrences) do
+        local region = Region:from_node(occurrence, refactor.bufnr)
+        table.insert(refactor.text_edits, {
+            add_newline = false,
+            region = region,
+            text = var_name,
+        })
+    end
+
+    local block_scope = refactor.ts.get_container(
+        refactor.region_node,
+        refactor.ts.block_scope
+    )
+
+    -- TODO: Add test for block_scope being nil
+    if block_scope == nil then
+        error("block_scope is nil! Something went wrong")
+    end
+
+    local unfiltered_statements = refactor.ts:get_statements(block_scope)
+
+    -- TODO: Add test for unfiltered_statements being nil
+    if #unfiltered_statements < 1 then
+        error("unfiltered_statements is nil! Something went wrong")
+    end
+
+    local statements = vim.tbl_filter(function(node)
+        return node:parent():id() == block_scope:id()
+    end, unfiltered_statements)
+    utils.sort_in_appearance_order(statements)
+
+    -- TODO: Add test for statements being nil
+    if #statements < 1 then
+        error("statements is nil! Something went wrong")
+    end
+
+    local contained = nil
+    local top_occurrence = actual_occurrences[1]
+    for _, statement in pairs(statements) do
+        if utils.node_contains(statement, top_occurrence) then
+            contained = statement
+        end
+    end
+
+    if not contained then
+        error(
+            "Extract var unable to determine its containing statement within the block scope, please post issue with exact highlight + code!  Thanks"
+        )
+    end
+    local code = refactor.code.constant({
+        name = var_name,
+        value = extract_node_text,
+    })
+
+    table.insert(refactor.text_edits, {
+        add_newline = false,
+        region = utils.region_one_line_up_from_node(contained),
+        text = code,
+    })
+end
+
 function M.extract_var(bufnr, config)
     Pipeline
         :from_task(refactor_setup(bufnr, config))
@@ -18,98 +110,7 @@ function M.extract_var(bufnr, config)
         end)
         :add_task(selection_setup)
         :add_task(function(refactor)
-            local extract_node = refactor.region_node
-
-            local extract_node_text = table.concat(
-                utils.get_node_text(extract_node),
-                ""
-            )
-
-            local sexpr = extract_node:sexpr()
-            local occurrences = Query.find_occurrences(
-                refactor.scope,
-                sexpr,
-                refactor.bufnr
-            )
-
-            local actual_occurrences = {}
-            local texts = {}
-
-            for _, occurrence in pairs(occurrences) do
-                local text = table.concat(utils.get_node_text(occurrence), "")
-                if text == extract_node_text then
-                    table.insert(actual_occurrences, occurrence)
-                    table.insert(texts, text)
-                end
-            end
-            utils.sort_in_appearance_order(actual_occurrences)
-
-            local var_name = get_input("119: What is the var name > ")
-            assert(var_name ~= "", "Error: Must provide new var name")
-
-            refactor.text_edits = {}
-            for _, occurrence in pairs(actual_occurrences) do
-                local region = Region:from_node(occurrence, refactor.bufnr)
-                table.insert(refactor.text_edits, {
-                    add_newline = false,
-                    region = region,
-                    text = var_name,
-                })
-            end
-
-            local block_scope = refactor.ts.get_container(
-                refactor.region_node,
-                refactor.ts.block_scope
-            )
-
-            -- TODO: Add test for block_scope being nil
-            if block_scope == nil then
-                error("block_scope is nil! Something went wrong")
-            end
-
-            local unfiltered_statements = refactor.ts:get_statements(
-                block_scope
-            )
-
-            -- TODO: Add test for unfiltered_statements being nil
-            if #unfiltered_statements < 1 then
-                error("unfiltered_statements is nil! Something went wrong")
-            end
-
-            local statements = vim.tbl_filter(function(node)
-                return node:parent():id() == block_scope:id()
-            end, unfiltered_statements)
-            utils.sort_in_appearance_order(statements)
-
-            -- TODO: Add test for statements being nil
-            if #statements < 1 then
-                error("statements is nil! Something went wrong")
-            end
-
-            local contained = nil
-            local top_occurrence = actual_occurrences[1]
-            for _, statement in pairs(statements) do
-                if utils.node_contains(statement, top_occurrence) then
-                    contained = statement
-                end
-            end
-
-            if not contained then
-                error(
-                    "Extract var unable to determine its containing statement within the block scope, please post issue with exact highlight + code!  Thanks"
-                )
-            end
-            local code = refactor.code.constant({
-                name = var_name,
-                value = extract_node_text,
-            })
-
-            table.insert(refactor.text_edits, {
-                add_newline = false,
-                region = utils.region_one_line_up_from_node(contained),
-                text = code,
-            })
-
+            extract_var_setup(refactor)
             return true, refactor
         end)
         :after(post_refactor)

--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -88,93 +88,83 @@ local function construct_new_declaration(
     return new_identifiers, new_values
 end
 
+local function inline_var_setup(refactor, bufnr)
+    -- figure out if we're dealing with a visual selection or a cursor node
+    local declarator_node, node_on_cursor = determine_declarator_node(
+        refactor,
+        bufnr
+    )
+
+    -- get all identifiers in the declarator node (for either situation)
+    local identifiers = refactor.ts:get_local_var_names(declarator_node)
+
+    -- these three vars are determined based on the situation (cursor node or selected declaration)
+    local node_to_inline, identifier_pos, definition
+
+    if node_on_cursor then
+        node_to_inline = ts.get_node_at_cursor(0)
+        definition = ts.find_definition(node_to_inline, bufnr)
+        identifier_pos = determine_identifier_position(identifiers, definition)
+    else
+        node_to_inline, identifier_pos = get_node_to_inline(identifiers, bufnr)
+        definition = ts.find_definition(node_to_inline, bufnr)
+    end
+
+    local references = ts.find_references(definition, nil, bufnr, definition)
+
+    local all_values = refactor.ts:get_local_var_values(declarator_node)
+    local value_node_to_inline = all_values[identifier_pos]
+
+    local text_edits = {}
+
+    -- remove the whole declaration if there is only one identifier, else construct a new declaration
+    if #identifiers == 1 then
+        table.insert(
+            text_edits,
+            lsp_utils.delete_text(Region:from_node(declarator_node, bufnr))
+        )
+    else
+        local new_identifiers_text, new_values_text = construct_new_declaration(
+            identifiers,
+            all_values,
+            node_to_inline,
+            bufnr
+        )
+
+        local insert_text, delete_text = lsp_utils.replace_text(
+            Region:from_node(declarator_node, bufnr),
+            refactor.code.constant({
+                multiple = true,
+                identifiers = new_identifiers_text,
+                values = new_values_text,
+            })
+        )
+
+        table.insert(text_edits, insert_text)
+        table.insert(text_edits, delete_text)
+    end
+
+    local value_text = ts.get_node_text(value_node_to_inline, bufnr)
+
+    for _, ref in pairs(references) do
+        -- TODO: In my mind, if nothing is left on the line when you remove, it should get deleted.
+        -- Could be done via opts into replace_text.
+        local insert_text, delete_text = lsp_utils.replace_text(
+            Region:from_node(ref),
+            value_text
+        )
+
+        table.insert(text_edits, insert_text)
+        table.insert(text_edits, delete_text)
+    end
+
+    refactor.text_edits = text_edits
+end
+
 function M.inline_var(bufnr, opts)
     get_inline_setup_pipeline(bufnr, opts)
         :add_task(function(refactor)
-            -- figure out if we're dealing with a visual selection or a cursor node
-            local declarator_node, node_on_cursor = determine_declarator_node(
-                refactor,
-                bufnr
-            )
-
-            -- get all identifiers in the declarator node (for either situation)
-            local identifiers = refactor.ts:get_local_var_names(declarator_node)
-
-            -- these three vars are determined based on the situation
-            local node_to_inline, identifier_pos, definition
-
-            if node_on_cursor then
-                node_to_inline = ts.get_node_at_cursor(0)
-                definition = ts.find_definition(node_to_inline, bufnr)
-                identifier_pos = determine_identifier_position(
-                    identifiers,
-                    definition
-                )
-            else
-                node_to_inline, identifier_pos = get_node_to_inline(
-                    identifiers,
-                    bufnr
-                )
-                definition = ts.find_definition(node_to_inline, bufnr)
-            end
-
-            local references = ts.find_references(
-                definition,
-                nil,
-                bufnr,
-                definition
-            )
-
-            local all_values = refactor.ts:get_local_var_values(declarator_node)
-            local value_node_to_inline = all_values[identifier_pos]
-
-            local text_edits = {}
-
-            -- only _emove declarator node if there is one declaration
-            if #identifiers == 1 then
-                table.insert(
-                    text_edits,
-                    lsp_utils.delete_text(
-                        Region:from_node(declarator_node, bufnr)
-                    )
-                )
-            else
-                local new_identifiers_text, new_values_text =
-                    construct_new_declaration(
-                        identifiers,
-                        all_values,
-                        node_to_inline,
-                        bufnr
-                    )
-
-                local insert_text, delete_text = lsp_utils.replace_text(
-                    Region:from_node(declarator_node, bufnr),
-                    refactor.code.constant({
-                        multiple = true,
-                        identifiers = new_identifiers_text,
-                        values = new_values_text,
-                    })
-                )
-
-                table.insert(text_edits, insert_text)
-                table.insert(text_edits, delete_text)
-            end
-
-            local value_text = ts.get_node_text(value_node_to_inline, bufnr)
-
-            for _, ref in pairs(references) do
-                -- TODO: In my mind, if nothing is left on the line when you remove, it should get deleted.
-                -- Could be done via opts into replace_text.
-                local insert_text, delete_text = lsp_utils.replace_text(
-                    Region:from_node(ref),
-                    value_text
-                )
-
-                table.insert(text_edits, insert_text)
-                table.insert(text_edits, delete_text)
-            end
-
-            refactor.text_edits = text_edits
+            inline_var_setup(refactor, bufnr)
             return true, refactor
         end)
         :after(post_refactor)


### PR DESCRIPTION
This is just to standardize the way the refactor functions are handled - simply moving everything in 123 and 119 to local functions and keeping the main code very minimal. More for readability than anything else.