### PR TITLE
add keymap example for inlining in normal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ vim.api.nvim_set_keymap("v", "<Leader>re", [[ <Esc><Cmd>lua require('refactoring
 vim.api.nvim_set_keymap("v", "<Leader>rf", [[ <Esc><Cmd>lua require('refactoring').refactor('Extract Function To File')<CR>]], {noremap = true, silent = true, expr = false})
 vim.api.nvim_set_keymap("v", "<Leader>rv", [[ <Esc><Cmd>lua require('refactoring').refactor('Extract Variable')<CR>]], {noremap = true, silent = true, expr = false})
 vim.api.nvim_set_keymap("v", "<Leader>ri", [[ <Esc><Cmd>lua require('refactoring').refactor('Inline Variable')<CR>]], {noremap = true, silent = true, expr = false})
+vim.api.nvim_set_keymap("n", "<Leader>ri", [[ <Esc><Cmd>lua require('refactoring').refactor('Inline Variable')<CR>]], {noremap = true, silent = true, expr = false})
 ```
 
 Notice that these maps are **visual mode** remaps, and that ESC is pressed before executing


### PR DESCRIPTION
Inlining a variable also works in normal mode. I got a bit confused while testing this plugin for the first time and nothing happened in normal mode. So hopefully this makes it more explicit.