### PR TITLE
feat: python typed and default parameter support for 106

### DIFF
--- a/lua/refactoring/tests/refactor/106/py/simple-function/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/simple-function/extract.expected.py
@@ -1,11 +1,11 @@
 
-def foo_bar(a, test, test_other):
+def foo_bar(a, b, c, d, test, test_other):
     for x in range(test_other + test):
-        print(x, a)
+        print(x, a, b, c, d)
 
 
-def simple_function(a):
+def simple_function(a, b: int, c=1, d: int = 2):
     test = 1
     test_other = 11
-    foo_bar(a, test, test_other)
+    foo_bar(a, b, c, d, test, test_other)
 

--- a/lua/refactoring/tests/refactor/106/py/simple-function/extract.start.py
+++ b/lua/refactoring/tests/refactor/106/py/simple-function/extract.start.py
@@ -1,5 +1,5 @@
-def simple_function(a):
+def simple_function(a, b: int, c=1, d: int = 2):
     test = 1
     test_other = 11
     for x in range(test_other + test):
-        print(x, a)
+        print(x, a, b, c, d)

--- a/lua/refactoring/treesitter/langs/python.lua
+++ b/lua/refactoring/treesitter/langs/python.lua
@@ -39,6 +39,15 @@ function Python.new(bufnr, ft)
             InlineNode(
                 "((function_definition (parameters (identifier) @tmp_capture)))"
             ),
+            InlineNode(
+                "((function_definition (parameters (default_parameter (identifier) @tmp_capture))))"
+            ),
+            InlineNode(
+                "((function_definition (parameters (typed_parameter (identifier) @tmp_capture))))"
+            ),
+            InlineNode(
+                "((function_definition (parameters (typed_default_parameter (identifier) @tmp_capture))))"
+            ),
         },
         local_var_values = {
             InlineNode("(assignment right: (_ (_) @tmp_capture))"),


### PR DESCRIPTION
Add treesitter detection for parameters with type hints and/or default values.