### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,43 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: Code Before refactor/debug operation
+    attributes:
+      label: Code Before refactor/debug operation
+      description: Show us what happened before operation
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: What refactor operation did you perform?
+    attributes:
+      label: Code operation befored
+      description: Code operation performed by plugin
+      placeholder: Examples are -> extract func, extract var, etc
+    validations:
+      required: true
+  - type: textarea
+    id: Code After refactor/debug operation
+    attributes:
+      label: Code After refactor/debug operation
+      description: Show us what happened after operation
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: What did you expected?
+    attributes:
+      label: what did you expect from operation
+      description: What did you expect to happen?
+  - type: textarea
+    id: Comments
+    attributes:
+      label: Other comments about issue
+      description: Any other comments about issue


### PR DESCRIPTION
@ThePrimeagen @pranavrao145 
Creating an issue template for bugs based on [this github feature](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). Hopefully this makes creating bugs more straightforward. Not sure of a way to test this prior to merge, so I can merge and play around with getting it right if we are alright with doing this. I can add one for feature requests also. 