### PR TITLE
feat: Add python param types if present during extract func

### DIFF
--- a/lua/refactoring/code_generation/langs/python.lua
+++ b/lua/refactoring/code_generation/langs/python.lua
@@ -1,7 +1,21 @@
 local code_utils = require("refactoring.code_generation.utils")
 local code_gen_indent = require("refactoring.code_generation.indent")
 
+local function build_args(args, arg_types)
+    local final_args = {}
+    for i, arg in pairs(args) do
+        local arg_key = arg .. ":"
+        if arg_types[arg_key] ~= code_utils.default_func_param_type() then
+            final_args[i] = arg .. ": " .. arg_types[arg_key]
+        else
+            final_args[i] = arg
+        end
+    end
+    return final_args
+end
+
 local function python_function(opts)
+    local args = build_args(opts.args, opts.args_types)
     if opts.func_header == nil then
         opts.func_header = ""
     end
@@ -14,12 +28,13 @@ local function python_function(opts)
 ]],
         opts.func_header,
         opts.name,
-        table.concat(opts.args, ", "),
+        table.concat(args, ", "),
         code_utils.stringify_code(opts.body)
     )
 end
 
 local function python_class_function(opts)
+    local args = build_args(opts.args, opts.args_types)
     if opts.func_header == nil then
         opts.func_header = ""
     end
@@ -32,7 +47,7 @@ local function python_class_function(opts)
 ]],
         opts.func_header,
         opts.name,
-        table.concat(opts.args, ", "),
+        table.concat(args, ", "),
         code_utils.stringify_code(opts.body)
     )
 end

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -65,8 +65,10 @@ local function get_function_param_types(refactor, args)
     )
     for _, arg in pairs(args) do
         local function_param_type
-        if parameter_arg_types[arg] ~= nil then
-            function_param_type = parameter_arg_types[arg]
+        local curr_arg = refactor.ts.get_arg_type_key(arg)
+
+        if parameter_arg_types[curr_arg] ~= nil then
+            function_param_type = parameter_arg_types[curr_arg]
         elseif
             refactor.config:get_prompt_func_param_type(refactor.filetype)
         then
@@ -80,8 +82,9 @@ local function get_function_param_types(refactor, args)
         else
             function_param_type = code_utils.default_func_param_type()
         end
-        args_types[arg] = function_param_type
+        args_types[curr_arg] = function_param_type
     end
+
     return args_types
 end
 

--- a/lua/refactoring/tests/refactor/106/py/simple-function/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/simple-function/extract.expected.py
@@ -1,5 +1,5 @@
 
-def foo_bar(a, b, c, d, test, test_other):
+def foo_bar(a, b: int, c, d: int, test, test_other):
     for x in range(test_other + test):
         print(x, a, b, c, d)
 

--- a/lua/refactoring/treesitter/langs/python.lua
+++ b/lua/refactoring/treesitter/langs/python.lua
@@ -6,9 +6,10 @@ local InlineNode = Nodes.InlineNode
 local Python = {}
 
 function Python.new(bufnr, ft)
-    return TreeSitter:new({
+    local ts = TreeSitter:new({
         filetype = ft,
         bufnr = bufnr,
+        require_param_types = true,
         scope_names = {
             function_definition = "function",
             module = "program",
@@ -69,7 +70,27 @@ function Python.new(bufnr, ft)
             for_statement = true,
             if_statement = true,
         },
+        function_scopes = {
+            function_definition = true,
+            if_statement = true,
+            module = true,
+        },
+        parameter_list = {
+            InlineNode(
+                "(function_definition parameters: (parameters((typed_parameter) @capture)))"
+            ),
+            InlineNode(
+                "(function_definition parameters: (parameters((typed_default_parameter) @capture)))"
+            ),
+        },
     }, bufnr)
+
+    -- overriding function
+    function ts.get_arg_type_key(arg)
+        return arg .. ":"
+    end
+
+    return ts
 end
 
 return Python

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -80,6 +80,10 @@ function TreeSitter:validate_setting(setting)
     end
 end
 
+function TreeSitter.get_arg_type_key(arg)
+    return arg
+end
+
 ---@return boolean: whether to allow indenting operations
 function TreeSitter:allows_indenting_task()
     return setting_present(self.indent_scopes)
@@ -216,6 +220,13 @@ function TreeSitter:get_local_parameter_types(scope)
     local parameter_types = {}
     local function_node = containing_node_by_type(scope, self.function_scopes)
 
+    -- TODO: Uncomment this error once validate settings in this func
+    -- if function_node == nil then
+    -- error(
+    -- "Failed to get function_node in get_local_parameter_types, check `function_scopes` queries"
+    -- )
+    -- end
+
     -- Get parameter list
     local parameter_list_nodes = self:loop_thru_nodes(
         function_node,
@@ -224,11 +235,14 @@ function TreeSitter:get_local_parameter_types(scope)
 
     -- Only if we find something, else empty
     if #parameter_list_nodes > 0 then
-        local region = Region:from_node(parameter_list_nodes[1])
-        local parameter_list = region:get_text()
-        local parameter_split = utils.split_string(parameter_list[1], " ")
-        parameter_types[parameter_split[1]] = parameter_split[2]
+        for _, node in pairs(parameter_list_nodes) do
+            local region = Region:from_node(node)
+            local parameter_list = region:get_text()
+            local parameter_split = utils.split_string(parameter_list[1], " ")
+            parameter_types[parameter_split[1]] = parameter_split[2]
+        end
     end
+
     return parameter_types
 end
 


### PR DESCRIPTION
@ThePrimeagen @pranavrao145 
feat: Add python param types if present during extract func

Wanted review as I am doing an override with treesitter here for python for a function. Wanted to make sure we are alright with overriding default treesitter behavior here for python arg param type key. We could probably override functions for other languages for specific operations so that the main refactor operations stay generic as possible.  