### PR TITLE
feat: Remove extra line after func call during extract func operation

### DIFF
--- a/lua/refactoring/code_generation/langs/cpp.lua
+++ b/lua/refactoring/code_generation/langs/cpp.lua
@@ -119,7 +119,7 @@ void %s(%s) {
         return code_utils.returnify(opts, "%s")
     end,
     terminate = function(code)
-        return code .. ";\n"
+        return code .. ";"
     end,
     indent_char_length = function(first_line)
         return code_gen_indent.indent_char_length(first_line, indent_char)

--- a/lua/refactoring/code_generation/langs/go.lua
+++ b/lua/refactoring/code_generation/langs/go.lua
@@ -188,7 +188,7 @@ local go = {
         return go_call_class_func(opts)
     end,
     terminate = function(code)
-        return code .. "\n"
+        return code
     end,
 }
 return go

--- a/lua/refactoring/code_generation/langs/java.lua
+++ b/lua/refactoring/code_generation/langs/java.lua
@@ -119,7 +119,7 @@ public static %s %s(%s) {
         return code_utils.returnify(opts, "%s")
     end,
     terminate = function(code)
-        return code .. ";\n"
+        return code .. ";"
     end,
     indent_char_length = function(first_line)
         return code_gen_indent.indent_char_length(first_line, indent_char)

--- a/lua/refactoring/code_generation/langs/lua.lua
+++ b/lua/refactoring/code_generation/langs/lua.lua
@@ -76,7 +76,7 @@ local lua = {
         return string.format("%s(%s)", opts.name, table.concat(opts.args, ", "))
     end,
     terminate = function(code)
-        return code .. "\n"
+        return code
     end,
     pack = function(opts)
         return code_utils.returnify(opts, "%s")

--- a/lua/refactoring/code_generation/langs/php.lua
+++ b/lua/refactoring/code_generation/langs/php.lua
@@ -76,7 +76,7 @@ local php = {
         )
     end,
     terminate = function(code)
-        return code .. ";\n"
+        return code .. ";"
     end,
     indent_char_length = function(first_line)
         return code_gen_indent.indent_char_length(first_line, indent_char)

--- a/lua/refactoring/code_generation/langs/python.lua
+++ b/lua/refactoring/code_generation/langs/python.lua
@@ -115,7 +115,7 @@ local python = {
         )
     end,
     terminate = function(code)
-        return code .. "\n"
+        return code
     end,
     pack = function(opts)
         return code_utils.returnify(opts, "%s")

--- a/lua/refactoring/code_generation/langs/typescript.lua
+++ b/lua/refactoring/code_generation/langs/typescript.lua
@@ -143,7 +143,7 @@ local typescript = {
         return string.format("%s(%s)", opts.name, table.concat(opts.args, ", "))
     end,
     terminate = function(code)
-        return code .. ";\n"
+        return code .. ";"
     end,
     indent_char_length = function(first_line)
         return code_gen_indent.indent_char_length(first_line, indent_char)

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -250,6 +250,8 @@ local function get_func_call(refactor, extract_params)
         func_call_with_indent[2] = func_call.text
         func_call.text = table.concat(func_call_with_indent, "")
     end
+
+    func_call.add_newline = false
     return func_call
 end
 

--- a/lua/refactoring/tests/refactor/106/c/global-scope/extract.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/global-scope/extract.expected.c
@@ -8,4 +8,3 @@ int main(int argc, char *argv[]) {
 }
 
 foo();
-

--- a/lua/refactoring/tests/refactor/106/c/prompt_func_param/extract.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/prompt_func_param/extract.expected.c
@@ -13,6 +13,5 @@ int simple_function(int a) {
   int test = 1;
   foo(a);
 
-
   return test;
 }

--- a/lua/refactoring/tests/refactor/106/c/prompt_param_func_no_return/extract.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/prompt_param_func_no_return/extract.expected.c
@@ -12,5 +12,4 @@ void foo(int a) {
 void simple_function(int a) {
   int test = 1;
   foo(a);
-
 }

--- a/lua/refactoring/tests/refactor/106/c/simple-function/extract.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/simple-function/extract.expected.c
@@ -11,5 +11,4 @@ void simple_function(int a) {
   int test = 1, test_other = 1;
 
   foo_bar(a, test, test_other);
-
 }

--- a/lua/refactoring/tests/refactor/106/c/with-comments/extract.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/with-comments/extract.expected.c
@@ -16,5 +16,4 @@ void simple_function(int a) {
   int test = 1, test_other = 1;
 
   foo_bar(a, test, test_other);
-
 }

--- a/lua/refactoring/tests/refactor/106/cpp/class-function/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/class-function/extract.expected.cpp
@@ -12,6 +12,5 @@ void foo(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_oth
   void simpleFunction(int a) {
     int test = 1, test_other = 11;
     foo(a, test, test_other);
-
   }
 };

--- a/lua/refactoring/tests/refactor/106/cpp/global-scope/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/global-scope/extract.expected.cpp
@@ -8,4 +8,3 @@ int main(int argc, char *argv[]) {
 }
 
 foo();
-

--- a/lua/refactoring/tests/refactor/106/cpp/prompt_func_param/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/prompt_func_param/extract.expected.cpp
@@ -13,6 +13,5 @@ int simple_function(int a) {
   int test = 1;
   foo(a);
 
-
   return test;
 }

--- a/lua/refactoring/tests/refactor/106/cpp/prompt_func_param_no_return/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/prompt_func_param_no_return/extract.expected.cpp
@@ -12,5 +12,4 @@ void foo(int a) {
 void simple_function(int a) {
   int test = 1;
   foo(a);
-
 }

--- a/lua/refactoring/tests/refactor/106/cpp/simple-function/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/simple-function/extract.expected.cpp
@@ -11,5 +11,4 @@ void simple_function(int a) {
   int test = 1, test_other = 1;
 
   foo_bar(a, test, test_other);
-
 }

--- a/lua/refactoring/tests/refactor/106/cpp/with-comments/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/with-comments/extract.expected.cpp
@@ -16,5 +16,4 @@ void simple_function(int a) {
   int test = 1, test_other = 1;
 
   foo_bar(a, test, test_other);
-
 }

--- a/lua/refactoring/tests/refactor/106/go/prompt_func_param_no_return/extract.expected.go
+++ b/lua/refactoring/tests/refactor/106/go/prompt_func_param_no_return/extract.expected.go
@@ -12,5 +12,4 @@ func simple_function(a int) {
 	var test int = 1
 	test_other := 1
 	foo_bar(a, test, test_other)
-
 }

--- a/lua/refactoring/tests/refactor/106/go/simple-function/extract.expected.go
+++ b/lua/refactoring/tests/refactor/106/go/simple-function/extract.expected.go
@@ -12,5 +12,4 @@ func simple_function(a int) {
 	var test int = 1
 	test_other := 1
 	foo_bar(a, test, test_other)
-
 }

--- a/lua/refactoring/tests/refactor/106/go/struct-2/extract.expected.go
+++ b/lua/refactoring/tests/refactor/106/go/struct-2/extract.expected.go
@@ -16,5 +16,4 @@ func (b *foobar) simple_function(a int) {
 	var test int = 1
 	test_other := 1
 	b.foo(a, test, test_other)
-
 }

--- a/lua/refactoring/tests/refactor/106/go/struct/extract.expected.go
+++ b/lua/refactoring/tests/refactor/106/go/struct/extract.expected.go
@@ -16,5 +16,4 @@ func (f *foobar) simple_function(a int) {
 	var test int = 1
 	test_other := 1
 	f.foo(a, test, test_other)
-
 }

--- a/lua/refactoring/tests/refactor/106/go/with-comment-above/extract.expected.go
+++ b/lua/refactoring/tests/refactor/106/go/with-comment-above/extract.expected.go
@@ -15,5 +15,4 @@ func simple_function(a int) {
 	var test int = 1
 	test_other := 1
 	foo_bar(a, test, test_other)
-
 }

--- a/lua/refactoring/tests/refactor/106/java/class-function/extract.expected.java
+++ b/lua/refactoring/tests/refactor/106/java/class-function/extract.expected.java
@@ -10,6 +10,5 @@ public static void foo(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM
   public static void simpleFunction(int a) {
     int test = 1, test_other = 11;
     foo(a, test, test_other);
-
   }
 }

--- a/lua/refactoring/tests/refactor/106/java/prompt_func_param/extract.expected.java
+++ b/lua/refactoring/tests/refactor/106/java/prompt_func_param/extract.expected.java
@@ -13,7 +13,6 @@ public static void foo(int a) {
     int test = 1;
     foo(a);
 
-
     return test;
   }
 }

--- a/lua/refactoring/tests/refactor/106/java/prompt_func_param_no_return/extract.expected.java
+++ b/lua/refactoring/tests/refactor/106/java/prompt_func_param_no_return/extract.expected.java
@@ -12,6 +12,5 @@ public static void foo(int a) {
   public static void simpleFunction(int a) {
     int test = 1;
     foo(a);
-
   }
 }

--- a/lua/refactoring/tests/refactor/106/java/with-comments/extract.expected.java
+++ b/lua/refactoring/tests/refactor/106/java/with-comments/extract.expected.java
@@ -15,6 +15,5 @@ public static void foo(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM
   public static void simpleFunction(int a) {
     int test = 1, test_other = 11;
     foo(a, test, test_other);
-
   }
 }

--- a/lua/refactoring/tests/refactor/106/js/simple-function/extract.expected.js
+++ b/lua/refactoring/tests/refactor/106/js/simple-function/extract.expected.js
@@ -9,5 +9,4 @@ function simple_function(a) {
     let test = 1;
     let test_other = 11
     foo_bar(a, test, test_other);
-
 }

--- a/lua/refactoring/tests/refactor/106/js/with-comments/extract.expected.js
+++ b/lua/refactoring/tests/refactor/106/js/with-comments/extract.expected.js
@@ -14,5 +14,4 @@ function simple_function(a) {
     let test = 1;
     let test_other = 11
     foo_bar(a, test, test_other);
-
 }

--- a/lua/refactoring/tests/refactor/106/lua/simple-function/extract.expected.lua
+++ b/lua/refactoring/tests/refactor/106/lua/simple-function/extract.expected.lua
@@ -11,5 +11,4 @@ function simple_function(a)
     local test = 1
     local test_other = 11
     foo_bar(a, test, test_other)
-
 end

--- a/lua/refactoring/tests/refactor/106/lua/with-comments/extract.expected.lua
+++ b/lua/refactoring/tests/refactor/106/lua/with-comments/extract.expected.lua
@@ -14,5 +14,4 @@ function simple_function(a)
     local test = 1
     local test_other = 11
     foo_bar(a, test, test_other)
-
 end

--- a/lua/refactoring/tests/refactor/106/py/class/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/class/extract.expected.py
@@ -10,4 +10,3 @@ class Poggers:
         test = 1
         test_other = 11
         self.foo(a, test, test_other)
-

--- a/lua/refactoring/tests/refactor/106/py/global-scope/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/global-scope/extract.expected.py
@@ -7,4 +7,3 @@ def foo():
 
 
 foo()
-

--- a/lua/refactoring/tests/refactor/106/py/indent-inside-for-loop/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/indent-inside-for-loop/extract.expected.py
@@ -8,4 +8,3 @@ def simple_function(a):
     test_other = 11
     for x in range(test_other + test):
         foo_bar(a, x)
-

--- a/lua/refactoring/tests/refactor/106/py/simple-function/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/simple-function/extract.expected.py
@@ -8,4 +8,3 @@ def simple_function(a, b: int, c=1, d: int = 2):
     test = 1
     test_other = 11
     foo_bar(a, b, c, d, test, test_other)
-

--- a/lua/refactoring/tests/refactor/106/py/with-comments/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/with-comments/extract.expected.py
@@ -12,4 +12,3 @@ def simple_function(a):
     test = 1
     test_other = 11
     foo_bar(a, test, test_other)
-

--- a/lua/refactoring/tests/refactor/106/ts/simple-function/extract.expected.ts
+++ b/lua/refactoring/tests/refactor/106/ts/simple-function/extract.expected.ts
@@ -9,5 +9,4 @@ function simple_function(a: number) {
     let test = 1;
     let test_other = 11
     foo_bar(a, test, test_other);
-
 }

--- a/lua/refactoring/tests/refactor/106/ts/with-comments/extract.expected.ts
+++ b/lua/refactoring/tests/refactor/106/ts/with-comments/extract.expected.ts
@@ -14,5 +14,4 @@ function simple_function(a: number) {
     let test = 1;
     let test_other = 11
     foo_bar(a, test, test_other);
-
 }


### PR DESCRIPTION
feat: Remove extra line after func call during extract func operation
The main changes are in the `terminate` function for each languages code gen removing the `\n` at the end. This should make the refactoring operation a little cleaner by removing extra line after function call. Ideally I can do something like this for extracted function calls so that the blank lines are kept to a minimum. Lmk if I should change anything. 