### PR TITLE
Change print var to always attempt to find variable, regardless of mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ vim.api.nvim_set_keymap(
 	{ noremap = true }
 )
 
--- Print var: this remap should be made in visual mode
-vim.api.nvim_set_keymap("v", "<leader>rv", ":lua require('refactoring').debug.print_var({})<CR>", { noremap = true })
+-- Print var: this remap should be made in normal mode. The plugin will automatically detect and print out the variable under the cursor.
+vim.api.nvim_set_keymap("n", "<leader>rv", ":lua require('refactoring').debug.print_var({})<CR>", { noremap = true })
 
 -- Cleanup function: this remap should be made in normal mode
 vim.api.nvim_set_keymap("n", "<leader>rc", ":lua require('refactoring').debug.cleanup({})<CR>", { noremap = true })

--- a/lua/refactoring/debug/print_var.lua
+++ b/lua/refactoring/debug/print_var.lua
@@ -11,41 +11,36 @@ local ensure_code_gen = require("refactoring.tasks.ensure_code_gen")
 local get_select_input = require("refactoring.get_select_input")
 
 local function get_variable()
-    local variable_region = Region:from_current_selection()
-    if
-        variable_region.start_col == 0
-        and variable_region.end_col == 0
-        and variable_region.start_row == 0
-        and variable_region.end_row == 0
-    then
-        local bufnr = 0
-        local root_lang_tree = parsers.get_parser(bufnr)
-        local current_pos = Point:from_cursor()
-        local line = current_pos.row
-        local col = current_pos.col
-        variable_region.start_row = current_pos.row
-        local lang_tree = root_lang_tree:language_for_range({
-            current_pos.row,
-            current_pos.col,
-            current_pos.row,
-            current_pos.col,
-        })
-        for _, tree in ipairs(lang_tree:trees()) do
-            local root = tree:root()
-            if
-                root and ts_utils.is_in_node_range(root, current_pos.row, col)
-            then
-                root:named_descendant_for_range(line, col, line, col)
-            end
+    local bufnr = 0
+    local root_lang_tree = parsers.get_parser(bufnr)
+    local current_pos = Point:from_cursor()
+    local line = current_pos.row
+    local col = current_pos.col
+
+    local lang_tree = root_lang_tree:language_for_range({
+        current_pos.row,
+        current_pos.col,
+        current_pos.row,
+        current_pos.col,
+    })
+
+    for _, tree in ipairs(lang_tree:trees()) do
+        local root = tree:root()
+        if root and ts_utils.is_in_node_range(root, current_pos.row, col) then
+            root:named_descendant_for_range(line, col, line, col)
         end
-        local node = ts_utils.get_node_at_cursor()
-        local filetype = vim.bo[bufnr].filetype
-        if filetype == "php" then
-            return "$" .. ts_utils.get_node_text(node)[1]
-        end
-        return ts_utils.get_node_text(node)[1]
     end
-    return variable_region:get_text()[1]
+
+    local node = ts_utils.get_node_at_cursor()
+    local filetype = vim.bo[bufnr].filetype
+
+    local node_text = vim.treesitter.query.get_node_text(node, bufnr)
+
+    if filetype == "php" then
+        return "$" .. node_text
+    end
+
+    return node_text
 end
 
 local function get_indent_amount(refactor)


### PR DESCRIPTION
As discussed in #312, this PR makes the default behaviour of print_var to find the variable under the cursor, regardless of mode, instead of simply printing whatever is in the visual selection. This means that, regardless of whether the user is in visual or normal mode, the behaviour is the same. Existing configs will not error out, but at the same time, the behavior will be smarter.

@teddylear take a look and let me know what you think!