### PR TITLE
Add spaces to debug print

### DIFF
--- a/lua/refactoring/debug/print_var.lua
+++ b/lua/refactoring/debug/print_var.lua
@@ -126,6 +126,7 @@ local function printDebug(bufnr, config)
                 lsp_utils.insert_new_line_text(
                     Region:from_point(point),
                     statement
+                        .. " "
                         .. refactor.code.comment("__AUTO_GENERATED_PRINT_VAR__"),
                     opts
                 ),

--- a/lua/refactoring/debug/printf.lua
+++ b/lua/refactoring/debug/printf.lua
@@ -57,6 +57,7 @@ local function printDebug(bufnr, config)
             }
 
             local full_print_statement = refactor.code.print(printf_opts)
+                .. " "
                 .. refactor.code.comment("__AUTO_GENERATED_PRINTF__")
 
             refactor.text_edits = {

--- a/lua/refactoring/tests/debug/print_var/c/global-scope/print_var.expected.c
+++ b/lua/refactoring/tests/debug/print_var/c/global-scope/print_var.expected.c
@@ -1,2 +1,2 @@
 int i = 3;
-printf(" i: %s \n", i);// __AUTO_GENERATED_PRINT_VAR__
+printf(" i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__

--- a/lua/refactoring/tests/debug/print_var/c/mutiple-statements/print_var.expected.c
+++ b/lua/refactoring/tests/debug/print_var/c/mutiple-statements/print_var.expected.c
@@ -1,4 +1,4 @@
 void simple_function() {
     int i = 3;
-    printf("custom print_var simple_function i: %d", i);// __AUTO_GENERATED_PRINT_VAR__
+    printf("custom print_var simple_function i: %d", i); // __AUTO_GENERATED_PRINT_VAR__
 }

--- a/lua/refactoring/tests/debug/print_var/c/simple-function-nor-mode/print_var.expected.c
+++ b/lua/refactoring/tests/debug/print_var/c/simple-function-nor-mode/print_var.expected.c
@@ -1,4 +1,4 @@
 void simple_function() {
     int i = 3;
-    printf("simple_function i: %s \n", i);// __AUTO_GENERATED_PRINT_VAR__
+    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
 }

--- a/lua/refactoring/tests/debug/print_var/c/simple-function/print_var.expected.c
+++ b/lua/refactoring/tests/debug/print_var/c/simple-function/print_var.expected.c
@@ -1,4 +1,4 @@
 void simple_function() {
     int i = 3;
-    printf("simple_function i: %s \n", i);// __AUTO_GENERATED_PRINT_VAR__
+    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
 }

--- a/lua/refactoring/tests/debug/print_var/cpp/class-function/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/class-function/print_var.expected.cpp
@@ -1,6 +1,6 @@
 class Poggers {
     void simple_function() {
         int i = 3;
-        printf("Poggers#simple_function i: %s \n", i);// __AUTO_GENERATED_PRINT_VAR__
+        printf("Poggers#simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
     }
 }

--- a/lua/refactoring/tests/debug/print_var/cpp/global-scope/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/global-scope/print_var.expected.cpp
@@ -1,2 +1,2 @@
 int i = 3;
-printf(" i: %s \n", i);// __AUTO_GENERATED_PRINT_VAR__
+printf(" i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__

--- a/lua/refactoring/tests/debug/print_var/cpp/mutiple-statements/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/mutiple-statements/print_var.expected.cpp
@@ -1,4 +1,4 @@
 void simple_function() {
     int i = 3;
-    printf("custom print_var simple_function i: %d", i);// __AUTO_GENERATED_PRINT_VAR__
+    printf("custom print_var simple_function i: %d", i); // __AUTO_GENERATED_PRINT_VAR__
 }

--- a/lua/refactoring/tests/debug/print_var/cpp/simple-function-nor-mode/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/simple-function-nor-mode/print_var.expected.cpp
@@ -1,4 +1,4 @@
 void simple_function() {
     int i = 3;
-    printf("simple_function i: %s \n", i);// __AUTO_GENERATED_PRINT_VAR__
+    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
 }

--- a/lua/refactoring/tests/debug/print_var/cpp/simple-function/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/simple-function/print_var.expected.cpp
@@ -1,4 +1,4 @@
 void simple_function() {
     int i = 3;
-    printf("simple_function i: %s \n", i);// __AUTO_GENERATED_PRINT_VAR__
+    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
 }

--- a/lua/refactoring/tests/debug/print_var/go/multiple-statements/print_var.expected.go
+++ b/lua/refactoring/tests/debug/print_var/go/multiple-statements/print_var.expected.go
@@ -5,7 +5,7 @@ import "fmt"
 func simple_function(a int) {
 	var test int = 1
 	test_other := 1
-	fmt.Println(fmt.Sprintf("custom print var simple_function test_other:: %v", test_other))// __AUTO_GENERATED_PRINT_VAR__
+	fmt.Println(fmt.Sprintf("custom print var simple_function test_other:: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR__
 	for idx := test - 1; idx < test_other; idx++ {
 		fmt.Println(idx, a)
 	}

--- a/lua/refactoring/tests/debug/print_var/go/simple-function-nor-mode/print_var.expected.go
+++ b/lua/refactoring/tests/debug/print_var/go/simple-function-nor-mode/print_var.expected.go
@@ -5,7 +5,7 @@ import "fmt"
 func simple_function(a int) {
 	var test int = 1
 	test_other := 1
-	fmt.Println(fmt.Sprintf("simple_function test_other: %v", test_other))// __AUTO_GENERATED_PRINT_VAR__
+	fmt.Println(fmt.Sprintf("simple_function test_other: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR__
 	for idx := test - 1; idx < test_other; idx++ {
 		fmt.Println(idx, a)
 	}

--- a/lua/refactoring/tests/debug/print_var/go/simple-function/print_var.expected.go
+++ b/lua/refactoring/tests/debug/print_var/go/simple-function/print_var.expected.go
@@ -5,7 +5,7 @@ import "fmt"
 func simple_function(a int) {
 	var test int = 1
 	test_other := 1
-	fmt.Println(fmt.Sprintf("simple_function test_other: %v", test_other))// __AUTO_GENERATED_PRINT_VAR__
+	fmt.Println(fmt.Sprintf("simple_function test_other: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR__
 	for idx := test - 1; idx < test_other; idx++ {
 		fmt.Println(idx, a)
 	}

--- a/lua/refactoring/tests/debug/print_var/java/class-function/print_var.expected.java
+++ b/lua/refactoring/tests/debug/print_var/java/class-function/print_var.expected.java
@@ -2,7 +2,7 @@ class Extract {
 
   public static void simpleFunction(int a) {
     int i = 3;
-    System.out.printf("Extract#simpleFunction i: %s \n", i);// __AUTO_GENERATED_PRINT_VAR__
+    System.out.printf("Extract#simpleFunction i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
     System.out.println(i);
   }
 }

--- a/lua/refactoring/tests/debug/print_var/java/multiple-statements/print_var.expected.java
+++ b/lua/refactoring/tests/debug/print_var/java/multiple-statements/print_var.expected.java
@@ -2,7 +2,7 @@ class Extract {
 
   public static void simpleFunction(int a) {
     int i = 3;
-    System.out.printf("custom print_var Extract#simpleFunction i:: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+    System.out.printf("custom print_var Extract#simpleFunction i:: %s", i); // __AUTO_GENERATED_PRINT_VAR__
     System.out.println(i);
   }
 }

--- a/lua/refactoring/tests/debug/print_var/js/class-function/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/class-function/print_var.expected.js
@@ -1,7 +1,7 @@
 class Poggers {
   simple_function() {
     const i = 3;
-    console.log("Poggers#simple_function i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+    console.log("Poggers#simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
     console.log(i);
   }
 }

--- a/lua/refactoring/tests/debug/print_var/js/global-scope/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/global-scope/print_var.expected.js
@@ -1,2 +1,2 @@
 const i = 3;
-console.log(" i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+console.log(" i: %s", i); // __AUTO_GENERATED_PRINT_VAR__

--- a/lua/refactoring/tests/debug/print_var/js/multiple-statements/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/multiple-statements/print_var.expected.js
@@ -1,5 +1,5 @@
 function simple_function() {
     const i = 3;
-    console.log("custom print var simple_function i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+    console.log("custom print var simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/print_var/js/simple-function-nor-mode/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/simple-function-nor-mode/print_var.expected.js
@@ -1,5 +1,5 @@
 function simple_function() {
     const i = 3;
-    console.log("simple_function i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/print_var/js/simple-function/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/simple-function/print_var.expected.js
@@ -1,5 +1,5 @@
 function simple_function() {
     const i = 3;
-    console.log("simple_function i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/print_var/lua/multiple-statements/print_var.expected.lua
+++ b/lua/refactoring/tests/debug/print_var/lua/multiple-statements/print_var.expected.lua
@@ -1,7 +1,7 @@
 function simple_function(a)
     local test = 1
     local test_other = 11
-    print("custom print_var simple_function test_other:", vim.inspect(test_other))-- __AUTO_GENERATED_PRINT_VAR__
+    print("custom print_var simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR__
     for idx = test - 1, test_other do
         print(idx, a)
     end

--- a/lua/refactoring/tests/debug/print_var/lua/simple-function-nor-mode/print_var.expected.lua
+++ b/lua/refactoring/tests/debug/print_var/lua/simple-function-nor-mode/print_var.expected.lua
@@ -1,7 +1,7 @@
 function simple_function(a)
     local test = 1
     local test_other = 11
-    print("simple_function test_other:", vim.inspect(test_other))-- __AUTO_GENERATED_PRINT_VAR__
+    print("simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR__
     for idx = test - 1, test_other do
         print(idx, a)
     end

--- a/lua/refactoring/tests/debug/print_var/lua/simple-function/print_var.expected.lua
+++ b/lua/refactoring/tests/debug/print_var/lua/simple-function/print_var.expected.lua
@@ -1,7 +1,7 @@
 function simple_function(a)
     local test = 1
     local test_other = 11
-    print("simple_function test_other:", vim.inspect(test_other))-- __AUTO_GENERATED_PRINT_VAR__
+    print("simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR__
     for idx = test - 1, test_other do
         print(idx, a)
     end

--- a/lua/refactoring/tests/debug/print_var/php/multiple-statements/print_var.expected.php
+++ b/lua/refactoring/tests/debug/print_var/php/multiple-statements/print_var.expected.php
@@ -1,6 +1,6 @@
 <?php
 function testFunction() {
     $testVariable = 'Hello Kiwi';
-    printf('custom print_var testFunction $testVariable: %s'."\n", $testVariable);// __AUTO_GENERATED_PRINT_VAR__
+    printf('custom print_var testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR__
 }
 ?>

--- a/lua/refactoring/tests/debug/print_var/php/simple-function-nor-mode/print_var.expected.php
+++ b/lua/refactoring/tests/debug/print_var/php/simple-function-nor-mode/print_var.expected.php
@@ -1,6 +1,6 @@
 <?php
 function testFunction() {
     $testVariable = 'Hello Kiwi';
-    printf('testFunction $testVariable: %s'."\n", $testVariable);// __AUTO_GENERATED_PRINT_VAR__
+    printf('testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR__
 }
 ?>

--- a/lua/refactoring/tests/debug/print_var/php/simple-function/print_var.expected.php
+++ b/lua/refactoring/tests/debug/print_var/php/simple-function/print_var.expected.php
@@ -1,6 +1,6 @@
 <?php
 function testFunction() {
     $testVariable = 'Hello Kiwi';
-    printf('testFunction $testVariable: %s'."\n", $testVariable);// __AUTO_GENERATED_PRINT_VAR__
+    printf('testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR__
 }
 ?>

--- a/lua/refactoring/tests/debug/print_var/py/multiple-statements/print_var.expected.py
+++ b/lua/refactoring/tests/debug/print_var/py/multiple-statements/print_var.expected.py
@@ -2,7 +2,7 @@ class Poggers:
 
     def simple_function(self, a):
         test = 1
-        print(f"custom print_var Poggers#simple_function test: {str(test)}")# __AUTO_GENERATED_PRINT_VAR__
+        print(f"custom print_var Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR__
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/debug/print_var/py/simple-function-nor-mode/print_var.expected.py
+++ b/lua/refactoring/tests/debug/print_var/py/simple-function-nor-mode/print_var.expected.py
@@ -2,7 +2,7 @@ class Poggers:
 
     def simple_function(self, a):
         test = 1
-        print(f"Poggers#simple_function test: {str(test)}")# __AUTO_GENERATED_PRINT_VAR__
+        print(f"Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR__
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/debug/print_var/py/simple-function/print_var.expected.py
+++ b/lua/refactoring/tests/debug/print_var/py/simple-function/print_var.expected.py
@@ -2,7 +2,7 @@ class Poggers:
 
     def simple_function(self, a):
         test = 1
-        print(f"Poggers#simple_function test: {str(test)}")# __AUTO_GENERATED_PRINT_VAR__
+        print(f"Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR__
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/debug/print_var/ts/class-function/print_var.expected.ts
+++ b/lua/refactoring/tests/debug/print_var/ts/class-function/print_var.expected.ts
@@ -1,7 +1,7 @@
 class Poggers {
   simple_function() {
     const i = 3;
-    console.log("Poggers#simple_function i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+    console.log("Poggers#simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
     console.log(i);
   }
 }

--- a/lua/refactoring/tests/debug/print_var/ts/global-scope/print_var.expected.ts
+++ b/lua/refactoring/tests/debug/print_var/ts/global-scope/print_var.expected.ts
@@ -1,2 +1,2 @@
 const i = 3;
-console.log(" i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+console.log(" i: %s", i); // __AUTO_GENERATED_PRINT_VAR__

--- a/lua/refactoring/tests/debug/print_var/ts/multiple-statements/print_var.expected.ts
+++ b/lua/refactoring/tests/debug/print_var/ts/multiple-statements/print_var.expected.ts
@@ -1,5 +1,5 @@
 function simple_function() {
     const i = 3;
-    console.log("custom print var simple_function i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+    console.log("custom print var simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/print_var/ts/simple-function/print_var.expected.ts
+++ b/lua/refactoring/tests/debug/print_var/ts/simple-function/print_var.expected.ts
@@ -1,5 +1,5 @@
 function simple_function() {
     const i = 3;
-    console.log("simple_function i: %s", i);// __AUTO_GENERATED_PRINT_VAR__
+    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/printf/c/multiple-statements/printf.expected.c
+++ b/lua/refactoring/tests/debug/printf/c/multiple-statements/printf.expected.c
@@ -1,5 +1,5 @@
 int main (int argc, char *argv[])
 {
-printf("debug path main");// __AUTO_GENERATED_PRINTF__
+printf("debug path main"); // __AUTO_GENERATED_PRINTF__
     return 0;
 }

--- a/lua/refactoring/tests/debug/printf/c/simple-function/printf.expected.c
+++ b/lua/refactoring/tests/debug/printf/c/simple-function/printf.expected.c
@@ -1,5 +1,5 @@
 int main() {
     return 0;
-printf("main(%d): \n", __LINE__);// __AUTO_GENERATED_PRINTF__
+printf("main(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
 }
 

--- a/lua/refactoring/tests/debug/printf/cpp/class-function/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/class-function/printf.expected.cpp
@@ -8,5 +8,5 @@ class Test {
 
 void Test::foo() {
 
-printf("Test::foo(%d): \n", __LINE__);// __AUTO_GENERATED_PRINTF__
+printf("Test::foo(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
 }

--- a/lua/refactoring/tests/debug/printf/cpp/destructor/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/destructor/printf.expected.cpp
@@ -4,7 +4,7 @@ class Test {
     public:
         ~Test() {
 
-printf("Test#~Test(%d): \n", __LINE__);// __AUTO_GENERATED_PRINTF__
+printf("Test#~Test(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
         }
 };
 

--- a/lua/refactoring/tests/debug/printf/cpp/inline-class-function/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/inline-class-function/printf.expected.cpp
@@ -5,7 +5,7 @@ class Test {
         ~Test() { }
         void foo() {
 
-printf("Test#foo(%d): \n", __LINE__);// __AUTO_GENERATED_PRINTF__
+printf("Test#foo(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
         }
 };
 

--- a/lua/refactoring/tests/debug/printf/cpp/multiple-statements/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/multiple-statements/printf.expected.cpp
@@ -1,5 +1,5 @@
 int main (int argc, char *argv[])
 {
-printf("debug path main");// __AUTO_GENERATED_PRINTF__
+printf("debug path main"); // __AUTO_GENERATED_PRINTF__
     return 0;
 }

--- a/lua/refactoring/tests/debug/printf/cpp/simple-function/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/simple-function/printf.expected.cpp
@@ -1,5 +1,5 @@
 int main() {
     return 0;
-printf("main(%d): \n", __LINE__);// __AUTO_GENERATED_PRINTF__
+printf("main(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
 }
 

--- a/lua/refactoring/tests/debug/printf/go/multiple-statements/printf.expected.go
+++ b/lua/refactoring/tests/debug/printf/go/multiple-statements/printf.expected.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func main()  {
     fmt.Println("test")
-fmt.Println("debug path main")// __AUTO_GENERATED_PRINTF__
+fmt.Println("debug path main") // __AUTO_GENERATED_PRINTF__
 }

--- a/lua/refactoring/tests/debug/printf/go/simple-function/printf.expected.go
+++ b/lua/refactoring/tests/debug/printf/go/simple-function/printf.expected.go
@@ -7,6 +7,6 @@ func simple_function(a int) {
 	test_other := 1
 	for idx := test - 1; idx < test_other; idx++ {
 		fmt.Println(idx, a)
-fmt.Println("simple_function")// __AUTO_GENERATED_PRINTF__
+fmt.Println("simple_function") // __AUTO_GENERATED_PRINTF__
 	}
 }

--- a/lua/refactoring/tests/debug/printf/java/class-function/printf.expected.java
+++ b/lua/refactoring/tests/debug/printf/java/class-function/printf.expected.java
@@ -3,7 +3,7 @@ class Extract {
   public static void simpleFunction(int a) {
     int test = 1, test_other = 11;
     for (int x = 0; x < test_other + test; x++) {
-System.out.println("Extract#simpleFunction#for");// __AUTO_GENERATED_PRINTF__
+System.out.println("Extract#simpleFunction#for"); // __AUTO_GENERATED_PRINTF__
       System.out.println(x + " " + a);
     }
   }

--- a/lua/refactoring/tests/debug/printf/java/multiple-statements/printf.expected.java
+++ b/lua/refactoring/tests/debug/printf/java/multiple-statements/printf.expected.java
@@ -1,6 +1,6 @@
 class Printf {
     public static void main(String[] args) {
         System.out.println("test");
-System.out.println("debug path Printf#main");// __AUTO_GENERATED_PRINTF__
+System.out.println("debug path Printf#main"); // __AUTO_GENERATED_PRINTF__
     }
 }

--- a/lua/refactoring/tests/debug/printf/js/multiple-statements/printf.expected.js
+++ b/lua/refactoring/tests/debug/printf/js/multiple-statements/printf.expected.js
@@ -1,4 +1,4 @@
 function main() {
-console.log("debug path main");// __AUTO_GENERATED_PRINTF__
+console.log("debug path main"); // __AUTO_GENERATED_PRINTF__
     return 0;
 }

--- a/lua/refactoring/tests/debug/printf/js/simple-function/printf.expected.js
+++ b/lua/refactoring/tests/debug/printf/js/simple-function/printf.expected.js
@@ -2,7 +2,7 @@ class foo {
 
     test() {
         "that seems wrong"
-console.log("foo#test");// __AUTO_GENERATED_PRINTF__
+console.log("foo#test"); // __AUTO_GENERATED_PRINTF__
         return 5
     }
 }

--- a/lua/refactoring/tests/debug/printf/lua/multiple-statements/printf.expected.lua
+++ b/lua/refactoring/tests/debug/printf/lua/multiple-statements/printf.expected.lua
@@ -1,4 +1,4 @@
 local hello = function ()
     print("test")
-print("debug path function");-- __AUTO_GENERATED_PRINTF__
+print("debug path function"); -- __AUTO_GENERATED_PRINTF__
 end

--- a/lua/refactoring/tests/debug/printf/lua/simple/printf.expected.lua
+++ b/lua/refactoring/tests/debug/printf/lua/simple/printf.expected.lua
@@ -1,4 +1,4 @@
 local function poggers()
     print("this function is quite simple indeed")
-print("poggers")-- __AUTO_GENERATED_PRINTF__
+print("poggers") -- __AUTO_GENERATED_PRINTF__
 end

--- a/lua/refactoring/tests/debug/printf/php/multiple-statements/printf.expected.php
+++ b/lua/refactoring/tests/debug/printf/php/multiple-statements/printf.expected.php
@@ -1,5 +1,5 @@
 <?php
 function testFunction() {
-printf("debug path testFunction");// __AUTO_GENERATED_PRINTF__
+printf("debug path testFunction"); // __AUTO_GENERATED_PRINTF__
 }
 ?>

--- a/lua/refactoring/tests/debug/printf/php/simple-function/printf.expected.php
+++ b/lua/refactoring/tests/debug/printf/php/simple-function/printf.expected.php
@@ -1,5 +1,5 @@
 <?php
 function testFunction() {
-printf("testFunction\n");// __AUTO_GENERATED_PRINTF__
+printf("testFunction\n"); // __AUTO_GENERATED_PRINTF__
 }
 ?>

--- a/lua/refactoring/tests/debug/printf/py/multiple-statements/printf.expected.py
+++ b/lua/refactoring/tests/debug/printf/py/multiple-statements/printf.expected.py
@@ -1,3 +1,3 @@
 def main():
-print("debug path main")# __AUTO_GENERATED_PRINTF__
+print("debug path main") # __AUTO_GENERATED_PRINTF__
     pass

--- a/lua/refactoring/tests/debug/printf/py/simple/printf.expected.py
+++ b/lua/refactoring/tests/debug/printf/py/simple/printf.expected.py
@@ -2,7 +2,7 @@ class Poggers:
 
     def simple_function(self, a):
         test = 1
-print(f"Poggers#simple_function")# __AUTO_GENERATED_PRINTF__
+print(f"Poggers#simple_function") # __AUTO_GENERATED_PRINTF__
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/debug/printf/ts/multiple-statements/printf.expected.ts
+++ b/lua/refactoring/tests/debug/printf/ts/multiple-statements/printf.expected.ts
@@ -1,4 +1,4 @@
 function main() {
-console.log("debug path main");// __AUTO_GENERATED_PRINTF__
+console.log("debug path main"); // __AUTO_GENERATED_PRINTF__
     return 0;
 }

--- a/lua/refactoring/tests/debug/printf/ts/simple-function/printf.expected.ts
+++ b/lua/refactoring/tests/debug/printf/ts/simple-function/printf.expected.ts
@@ -2,7 +2,7 @@ class foo {
 
     test() {
         "that seems wrong"
-console.log("foo#test");// __AUTO_GENERATED_PRINTF__
+console.log("foo#test"); // __AUTO_GENERATED_PRINTF__
         return 5
     }
 }


### PR DESCRIPTION
Admittedly a little silly, but something I've been wanting to do for a while. Just adds a space in between the print statement and the comment. Meant to do this when I first implemented this functionality but forgot. 