### PR TITLE
fix(python-extract-bloc): added special condition for extract var where there is nothing after the expression to extract on the same line

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,10 @@ sequence like this: `%%s`. For an example custom print var statement, go to
 [this folder](lua/refactoring/tests/debug/print_var), select your language, and
 view `multiple-statements/print_var.config`.
 
-**Note:** for either of these functions, if you have multiple statements
-(including the default), the plugin will prompt for which one should be inserted.
+**Note:** for either of these functions, if you have multiple custom
+statements, the plugin will prompt for which one should be inserted. If you
+just have one custom statement in your config, it will override the default
+automatically.
 
 ### Configuration for Type Prompt Operations<a name="config-prompt"></a>
 

--- a/lua/refactoring/utils.lua
+++ b/lua/refactoring/utils.lua
@@ -110,7 +110,13 @@ function M.node_contains(a, b)
         return false
     end
 
+    local _, _, _, a_end_col = a:range()
     local start_row, start_col, end_row, end_col = b:range()
+
+    if end_col == a_end_col then
+        end_col = end_col - 1
+    end
+
     return ts_utils.is_in_node_range(a, start_row, start_col)
         and ts_utils.is_in_node_range(a, end_row, end_col)
 end


### PR DESCRIPTION
@teddylear This will fix the issue outlined by #235. Turns out the check in the utils to see if the node was included in the given containing node was not inclusive, causing problems if there was nothing else on the line after the expression to be extracted. Just wanted to see what you thought about this before merging because it messes with the utils, but on the other hand it should fix the problem for any language in the future. Take a look and let me know what you think!

P.S. You can disregard the second commit, just an inconsistency I spotted in the README, might as well just do it in the same PR.