### PR TITLE
refactor: Use treesitter predicate functions to remove 'self' keyword when capturing python variables. I had no idea these were a thing

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,7 +8,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: JohnnyMorganz/stylua-action@1.0.0
+            - uses: JohnnyMorganz/stylua-action@v2
               with:
                 token: ${{ secrets.GITHUB_TOKEN }}
+                version: latest
                 args: --check .

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -339,12 +339,6 @@ local function get_selected_locals(refactor, is_class)
     end
 
     local local_def_map = utils.node_text_to_set(local_defs)
-    -- HACK: Can't think of a better way to do this right now,
-    -- just removing `self` if captured
-    if refactor.filetype == "python" and is_class then
-        local_def_map["self"] = nil
-    end
-
     local region_refs_map = utils.node_text_to_set(region_refs)
     return utils.table_key_intersect(local_def_map, region_refs_map)
 end

--- a/lua/refactoring/treesitter/langs/python.lua
+++ b/lua/refactoring/treesitter/langs/python.lua
@@ -23,24 +23,28 @@ function Python.new(bufnr, ft)
             assignment = true,
         },
         local_var_names = {
-            InlineNode("(assignment left: (_ (_) @tmp_capture))"),
-            InlineNode("(assignment left: (_) @tmp_capture)"),
             InlineNode(
-                "(for_statement left: (identifier) @definition.local_name)"
+                '((assignment left: (_ (_) @capture)) (#not-eq? @capture "self"))'
+            ),
+            InlineNode(
+                '((assignment left: (_) @capture) (#not-eq? @capture "self"))'
+            ),
+            InlineNode(
+                '((for_statement left: (identifier) @capture) (#not-eq? @capture "self"))'
             ),
         },
         function_args = {
             InlineNode(
-                "((function_definition (parameters (identifier) @tmp_capture)))"
+                '((function_definition (parameters (identifier) @capture)) (#not-eq? @capture "self"))'
             ),
             InlineNode(
-                "((function_definition (parameters (default_parameter (identifier) @tmp_capture))))"
+                '((function_definition (parameters (default_parameter (identifier) @capture))) (#not-eq? @capture "self"))'
             ),
             InlineNode(
-                "((function_definition (parameters (typed_parameter (identifier) @tmp_capture))))"
+                '((function_definition (parameters (typed_parameter (identifier) @capture))) (#not-eq? @capture "self"))'
             ),
             InlineNode(
-                "((function_definition (parameters (typed_default_parameter (identifier) @tmp_capture))))"
+                '((function_definition (parameters (typed_default_parameter (identifier) @capture))) (#not-eq? @capture "self"))'
             ),
         },
         local_var_values = {


### PR DESCRIPTION
refactor: Use treesitter predicate functions to remove 'self' keyword when capturing python variables. I had no idea these were a thing

Also update formatting CI task to latest. 

@pranavrao145 Sorry I haven't gotten a chance to work on this in a while, trying to get back into it again. Saw treesitter predicate functions at neovim conf and had no idea these were a thing. It will make removing certain keywords a lot easier along with some complex treesitter queries. 