### PR TITLE
Fix(select_refactor): properly return a value

### DIFF
--- a/lua/refactoring/init.lua
+++ b/lua/refactoring/init.lua
@@ -36,18 +36,18 @@ function M.get_refactors()
 end
 
 function M.select_refactor(opts)
-    local selected_refactor
-
     async.run(function()
+        local selected_refactor
+
         selected_refactor = get_select_input(
             M.get_refactors(),
             "Refactoring: select a refactor to apply:"
         )
-    end)
 
-    if selected_refactor then
-        M.refactor(selected_refactor, opts)
-    end
+        if selected_refactor then
+            M.refactor(selected_refactor, opts)
+        end
+    end)
 end
 
 M.debug = require("refactoring.debug")


### PR DESCRIPTION
Thanks for your efforts on this plugin 💙 

I've tried using this plugin in the past but it didn't work for me when following the [Using Built-In Neovim Selection](https://github.com/ThePrimeagen/refactoring.nvim#using-built-in-neovim-selection) setup. I would pick a refactoring and nothing would happen. I did some investigation and the problem is that `select_refactor` didn't receive my selection so `M.refactor` is never called.

The problem here seems to be the `selected_refactor` variable is evaluated before the internal async function in `get_select_input` is resolved.

Moving the evaluation into the `async.run` solves the issue.