### PR TITLE
WIP: Add additional config option for operator-pending maps

### DIFF
--- a/lua/refactoring/config/init.lua
+++ b/lua/refactoring/config/init.lua
@@ -54,6 +54,8 @@ local default_printf_statements = {}
 
 local default_print_var_statements = {}
 
+local default_use_motion = false
+
 ---@class Config
 ---@field config table
 local Config = {}
@@ -71,6 +73,7 @@ function Config:new(...)
         prompt_func_param_type = default_prompt_func_param_type,
         printf_statements = default_printf_statements,
         print_var_statements = default_print_var_statements,
+        use_motion = default_use_motion,
     })
 
     for idx = 1, select("#", ...) do
@@ -97,6 +100,7 @@ function Config:reset()
     self.config.prompt_func_param_type = default_prompt_func_param_type
     self.config.printf_statements = default_printf_statements
     self.config.print_var_statements = default_print_var_statements
+    self.config.use_motion = default_use_motion
 end
 
 function Config:automate_input(inputs)

--- a/lua/refactoring/region.lua
+++ b/lua/refactoring/region.lua
@@ -14,6 +14,15 @@ local function get_selection_range()
     return start_row, start_col, end_row, end_col
 end
 
+local function get_motion_range()
+    local start_row = vim.fn.line("'[")
+    local start_col = vim.fn.col("'[")
+    local end_row = vim.fn.line("']")
+    local end_col = vim.fn.col("']")
+
+    return start_row, start_col, end_row, end_col
+end
+
 ---@class RefactorRegion
 --- The following fields act similar to a cursor
 ---@field start_row number: The 1-based row
@@ -26,8 +35,26 @@ Region.__index = Region
 
 --- Get a Region from the current selection
 ---@return RefactorRegion
-function Region:from_current_selection()
-    local start_row, start_col, end_row, end_col = get_selection_range()
+function Region:from_current_selection(use_motion)
+    local start_row, start_col, end_row, end_col
+
+    if use_motion then
+        start_row, start_col, end_row, end_col = get_motion_range()
+    else
+        start_row, start_col, end_row, end_col = get_selection_range()
+    end
+
+    return setmetatable({
+        bufnr = vim.fn.bufnr(),
+        start_row = start_row,
+        start_col = start_col,
+        end_row = end_row,
+        end_col = end_col,
+    }, self)
+end
+
+function Region:from_motion()
+    local start_row, start_col, end_row, end_col = get_motion_range()
 
     return setmetatable({
         bufnr = vim.fn.bufnr(),

--- a/lua/refactoring/tasks/selection_setup.lua
+++ b/lua/refactoring/tasks/selection_setup.lua
@@ -1,7 +1,8 @@
 local Region = require("refactoring.region")
 
 local function selection_setup(refactor)
-    local region = Region:from_current_selection(refactor.bufnr)
+    local use_motion = refactor.config:get().use_motion
+    local region = Region:from_current_selection(use_motion)
     local region_node = region:to_ts_node(refactor.ts:get_root())
     local scope = refactor.ts:get_scope(region_node)
 

--- a/lua/telescope/_extensions/refactoring.lua
+++ b/lua/telescope/_extensions/refactoring.lua
@@ -1,15 +1,18 @@
 local refactoring = require("refactoring")
 
 -- refactoring helper
-local function refactor(prompt_bufnr)
+local function refactor(prompt_bufnr, opts)
     local content =
         require("telescope.actions.state").get_selected_entry(prompt_bufnr)
     require("telescope.actions").close(prompt_bufnr)
-    refactoring.refactor(content.value)
+    refactoring.refactor(content.value, opts)
 end
 
 local function telescope_refactoring(opts)
     opts = opts or require("telescope.themes").get_cursor()
+
+    local use_motion = opts.use_motion and true or false
+    opts.use_motion = nil
 
     require("telescope.pickers")
         .new(opts, {
@@ -19,8 +22,11 @@ local function telescope_refactoring(opts)
             }),
             sorter = require("telescope.config").values.generic_sorter(opts),
             attach_mappings = function(_, map)
-                map("i", "<CR>", refactor)
-                map("n", "<CR>", refactor)
+                local do_refactor = function(bufnr)
+                    refactor(bufnr, { use_motion = use_motion })
+                end
+                map("i", "<CR>", do_refactor)
+                map("n", "<CR>", do_refactor)
                 return true
             end,
         })


### PR DESCRIPTION
This PR addresses #275 and adds an additional `use_motion` option to be used in mappings.

I wouldn't consider this PR merge-ready just yet, I still need to add docs and tests and tinker with a few more things; I mostly just wanted to get feedback from people who are more familiar with writing plugins than I am... and Lua... 😄 

To use this, one could create a mapping like so:
```vim
" This could probably be added as a <Plug> mapping... it's kinda a monstrosity
nnoremap <Leader>ef <Cmd>let &operatorfunc={->luaeval("require'refactoring'.refactor('Extract Function',{use_motion=true})")}<CR>g@
```

In order to:
- `<Leader>ef2j` -> Extract the next two lines to a function
- `<Leader>efip` -> Extract a paragraph to a function
- `<Leader>efab` -> Extract a block to a function
- etc...

The same `use_motion` option can be passed to the Telescope extension as well.