### PR TITLE
fix: change deprecated code

### DIFF
--- a/lua/refactoring/dev.lua
+++ b/lua/refactoring/dev.lua
@@ -14,7 +14,7 @@ function M.create_query_from_buffer()
     return Query:new(
         bufnr,
         filetype,
-        vim.treesitter.get_query(filetype, "refactoring")
+        vim.treesitter.query.get(filetype, "refactoring")
     )
 end
 
@@ -45,7 +45,7 @@ function M.debug_current_selection()
     print("Region", vim.inspect(region))
     print(
         "Selection:Scope",
-        vim.inspect(vim.treesitter.query.get_node_text(scope, bufnr))
+        vim.inspect(vim.treesitter.get_node_text(scope, bufnr))
     )
 end
 
@@ -65,7 +65,7 @@ function M.print_local_def()
     print(vim.inspect(def))
     print(def[1]:type())
     print(
-        vim.treesitter.query.get_node_text(def, vim.api.nvim_get_current_buf())
+        vim.treesitter.get_node_text(def, vim.api.nvim_get_current_buf())
     )
 end
 
@@ -77,7 +77,7 @@ end
 function M.print_scope(scope)
     print(
         vim.inspect(
-            vim.treesitter.query.get_node_text(
+            vim.treesitter.get_node_text(
                 scope,
                 vim.api.nvim_get_current_buf()
             )

--- a/lua/refactoring/query.lua
+++ b/lua/refactoring/query.lua
@@ -28,7 +28,7 @@ function Query.get_root(bufnr, filetype)
 end
 
 function Query.from_query_name(bufnr, filetype, query_name)
-    local query = vim.treesitter.get_query(filetype, query_name)
+    local query = vim.treesitter.query.get(filetype, query_name)
     return Query:new(bufnr, filetype, query)
 end
 
@@ -66,7 +66,7 @@ function Query.find_occurrences(scope, sexpr, bufnr)
         sexpr = sexpr .. " @tmp_capture"
     end
 
-    local ok, sexpr_query = pcall(vim.treesitter.parse_query, filetype, sexpr)
+    local ok, sexpr_query = pcall(vim.treesitter.query.parse, filetype, sexpr)
     if not ok then
         error(
             string.format("Invalid query: '%s'\n error: %s", sexpr, sexpr_query)

--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -60,7 +60,7 @@ local function get_node_to_inline(identifiers, bufnr)
             identifiers,
             "123: Select an identifier to inline:",
             function(node)
-                return vim.treesitter.query.get_node_text(node, bufnr)
+                return vim.treesitter.get_node_text(node, bufnr)
             end
         )
     end
@@ -80,11 +80,11 @@ local function construct_new_declaration(
         if identifier ~= identifer_to_exclude then
             table.insert(
                 new_identifiers,
-                vim.treesitter.query.get_node_text(identifier, bufnr)
+                vim.treesitter.get_node_text(identifier, bufnr)
             )
             table.insert(
                 new_values,
-                vim.treesitter.query.get_node_text(values[idx], bufnr)
+                vim.treesitter.get_node_text(values[idx], bufnr)
             )
         end
     end
@@ -165,7 +165,7 @@ local function inline_var_setup(refactor, bufnr)
     end
 
     local value_text =
-        vim.treesitter.query.get_node_text(value_node_to_inline, bufnr)
+        vim.treesitter.get_node_text(value_node_to_inline, bufnr)
 
     for _, ref in pairs(references) do
         -- TODO: In my mind, if nothing is left on the line when you remove, it should get deleted.

--- a/lua/refactoring/tests/treesitter/treesitter_spec.lua
+++ b/lua/refactoring/tests/treesitter/treesitter_spec.lua
@@ -113,11 +113,11 @@ describe("TreeSitter", function()
         local cur_bufnr = vim.api.nvim_get_current_buf()
         assert.are.same(
             "let foo = 5;",
-            vim.treesitter.query.get_node_text(local_vars[1], cur_bufnr)
+            vim.treesitter.get_node_text(local_vars[1], cur_bufnr)
         )
         assert.are.same(
             "const bar = 5;",
-            vim.treesitter.query.get_node_text(local_vars[2], cur_bufnr)
+            vim.treesitter.get_node_text(local_vars[2], cur_bufnr)
         )
     end)
 
@@ -127,7 +127,7 @@ describe("TreeSitter", function()
         set_position(33, 10)
         local node = ts:local_declarations_under_cursor()
 
-        assert.are.same("const bar = 5;", vim.treesitter.query.get_node_text(node, vim.api.nvim_get_current_buf()))
+        assert.are.same("const bar = 5;", vim.treesitter.get_node_text(node, vim.api.nvim_get_current_buf()))
     end)
 
     it("Inline Node basic test root scope", function()
@@ -140,19 +140,19 @@ describe("TreeSitter", function()
         local cur_bufnr = vim.api.nvim_get_current_buf()
         assert.are.same(
             "return test;",
-            vim.treesitter.query.get_node_text(inline_node_result[1], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[1], cur_bufnr)
         )
         assert.are.same(
             "return 5;",
-            vim.treesitter.query.get_node_text(inline_node_result[2], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[2], cur_bufnr)
         )
         assert.are.same(
             "return 5;",
-            vim.treesitter.query.get_node_text(inline_node_result[3], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[3], cur_bufnr)
         )
         assert.are.same(
             "return inner() * foo * bar;",
-            vim.treesitter.query.get_node_text(inline_node_result[4], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[4], cur_bufnr)
         )
     end)
 
@@ -167,11 +167,11 @@ describe("TreeSitter", function()
         local cur_bufnr = vim.api.nvim_get_current_buf()
         assert.are.same(
             "return 5;",
-            vim.treesitter.query.get_node_text(inline_node_result[1], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[1], cur_bufnr)
         )
         assert.are.same(
             "return inner() * foo * bar;",
-            vim.treesitter.query.get_node_text(inline_node_result[2], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[2], cur_bufnr)
         )
     end)
 
@@ -184,39 +184,39 @@ describe("TreeSitter", function()
         local cur_bufnr = vim.api.nvim_get_current_buf()
         assert.are.same(
             "return 5;",
-            vim.treesitter.query.get_node_text(inline_node_result[1], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[1], cur_bufnr)
         )
         assert.are.same(
             "return inner() * foo * bar;",
-            vim.treesitter.query.get_node_text(inline_node_result[2], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[2], cur_bufnr)
         )
         assert.are.same(
             "if (true) {\n            let fazz = 7;\n        }",
-            vim.treesitter.query.get_node_text(inline_node_result[3], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[3], cur_bufnr)
         )
         assert.are.same(
             "if (true) {\n            let buzzzbaszz = 69;\n        }",
-            vim.treesitter.query.get_node_text(inline_node_result[4], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[4], cur_bufnr)
         )
         assert.are.same(
             "let foo = 5;",
-            vim.treesitter.query.get_node_text(inline_node_result[5], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[5], cur_bufnr)
         )
         assert.are.same(
             "const bar = 5;",
-            vim.treesitter.query.get_node_text(inline_node_result[6], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[6], cur_bufnr)
         )
         assert.are.same(
             "let baz = 5;",
-            vim.treesitter.query.get_node_text(inline_node_result[7], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[7], cur_bufnr)
         )
         assert.are.same(
             "let fazz = 7;",
-            vim.treesitter.query.get_node_text(inline_node_result[8], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[8], cur_bufnr)
         )
         assert.are.same(
             "let buzzzbaszz = 69;",
-            vim.treesitter.query.get_node_text(inline_node_result[9], cur_bufnr)
+            vim.treesitter.get_node_text(inline_node_result[9], cur_bufnr)
         )
     end)
 

--- a/lua/refactoring/tests/utils_spec.lua
+++ b/lua/refactoring/tests/utils_spec.lua
@@ -43,7 +43,7 @@ describe("Utils", function()
         local query = Query:new(
             bufnr,
             filetype,
-            vim.treesitter.get_query(filetype, "locals")
+            vim.treesitter.query.get(filetype, "locals")
         )
         local root = Query.get_root(bufnr, filetype)
 
@@ -56,10 +56,10 @@ describe("Utils", function()
         local intersections = utils.region_intersect(captures, region)
 
         assert.are.same(#intersections, 1)
-        assert.are.same(vim.treesitter.query.get_node_text(intersections[1], bufnr), "bar")
+        assert.are.same(vim.treesitter.get_node_text(intersections[1], bufnr), "bar")
         local complements = utils.region_complement(captures, region)
 
         assert.are.same(#complements, 1)
-        assert.are.same(vim.treesitter.query.get_node_text(complements[1], bufnr), "foo")
+        assert.are.same(vim.treesitter.get_node_text(complements[1], bufnr), "foo")
     end)
 end)

--- a/lua/refactoring/treesitter/nodes.lua
+++ b/lua/refactoring/treesitter/nodes.lua
@@ -39,7 +39,7 @@ local FieldNode = function(...)
                     curr = curr[1]
                 end
 
-                return vim.treesitter.query.get_node_text(curr, 0) or fallback
+                return vim.treesitter.get_node_text(curr, 0) or fallback
             end,
         })
     end
@@ -58,7 +58,7 @@ end
 local InlineNode = function(sexpr)
     return function(scope, bufnr, filetype)
         local ok, result_object =
-            pcall(vim.treesitter.parse_query, filetype, sexpr)
+            pcall(vim.treesitter.query.parse, filetype, sexpr)
         if not ok then
             error(
                 string.format(
@@ -85,7 +85,7 @@ local QueryNode = function(sexpr)
         local first = occurrences[1]
 
         if first then
-            local res = vim.treesitter.query.get_node_text(
+            local res = vim.treesitter.get_node_text(
                 first,
                 vim.api.nvim_get_current_buf()
             )

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -165,7 +165,7 @@ function TreeSitter:is_class_function(scope)
 end
 
 function TreeSitter:get_references(scope)
-    local query = vim.treesitter.get_query(self.filetype, "locals")
+    local query = vim.treesitter.query.get(self.filetype, "locals")
     local out = {}
     for id, node, _ in query:iter_captures(scope, self.bufnr, 0, -1) do
         local n_capture = query.captures[id]

--- a/lua/refactoring/utils.lua
+++ b/lua/refactoring/utils.lua
@@ -80,7 +80,7 @@ function M.get_node_text(node, out)
         or node:type() == "interpreted_string_literal"
     then
         local cur_bufnr = vim.api.nvim_get_current_buf()
-        local text = vim.treesitter.query.get_node_text(node, cur_bufnr)
+        local text = vim.treesitter.get_node_text(node, cur_bufnr)
         table.insert(out, text)
         return out
     end
@@ -170,7 +170,7 @@ function M.node_text_to_set(...)
         local nodes = select(i, ...)
         local cur_bufnr = vim.api.nvim_get_current_buf()
         for _, node in pairs(nodes) do
-            local text = vim.treesitter.query.get_node_text(node, cur_bufnr)
+            local text = vim.treesitter.get_node_text(node, cur_bufnr)
             if text ~= nil then
                 out[text] = true
             end


### PR DESCRIPTION
There are some functions that are deprecated and will be removed in the next nvim version:

vim.treesitter.parse_query() is deprecated, use vim.treesitter.query.parse_query() instead. :help deprecated
This feature will be removed in Nvim version 0.10

vim.treesitter.query.parse_query() is deprecated, use vim.treesitter.query.parse() instead. :help deprecated
This feature will be removed in Nvim version 0.10

vim.treesitter.get_query() is deprecated, use vim.treesitter.query.get_query() instead. :help deprecated
This feature will be removed in Nvim version 0.10

vim.treesitter.query.get_node_text() is deprecated, use vim.treesitter.get_node_text() instead. :help deprecated
This feature will be removed in Nvim version 0.10

