### PR TITLE
Fix #373. Fix #358

### DIFF
--- a/lua/refactoring/debug/print_var.lua
+++ b/lua/refactoring/debug/print_var.lua
@@ -58,6 +58,8 @@ local function printDebug(bufnr, config)
 
                 -- always go below for text
                 opts.below = true
+                -- always go end for text
+                opts._end = true
                 point.col = opts.below and 100000 or 1
 
                 if opts.normal == nil then

--- a/lua/refactoring/debug/printf.lua
+++ b/lua/refactoring/debug/printf.lua
@@ -27,6 +27,10 @@ local function printDebug(bufnr, config)
                 if opts.below == nil then
                     opts.below = true
                 end
+                -- set default `end` behavior
+                if opts._end == nil then
+                    opts._end = true
+                end
                 point.col = opts.below and 100000 or 1
 
                 local indentation

--- a/lua/refactoring/get_input.lua
+++ b/lua/refactoring/get_input.lua
@@ -3,7 +3,6 @@ local Config = require("refactoring.config")
 -- This will be able to be hot swapped out with better input capture as we
 -- go on.  This is just a place holder
 local async = require("plenary.async")
--- local input = vim.fn.input
 local input = async.wrap(function(prompt, text, completion, callback)
     vim.ui.input({
         prompt = prompt,

--- a/lua/refactoring/get_select_input.lua
+++ b/lua/refactoring/get_select_input.lua
@@ -1,9 +1,6 @@
 local Config = require("refactoring.config")
 
--- This will be able to be hot swapped out with better input capture as we
--- go on.  This is just a place holder
 local async = require("plenary.async")
--- local input = vim.fn.input
 local select_input = async.wrap(function(items, prompt, format, kind, callback)
     vim.ui.select(items, {
         prompt = prompt,

--- a/lua/refactoring/init.lua
+++ b/lua/refactoring/init.lua
@@ -28,7 +28,7 @@ function M.refactor(name, opts)
     -- Remove the calls to vim.fn
     -- I just forgot the name of this ;)
     local config = Config.get():merge(opts)
-    refactors[refactor](vim.api.nvim_buf_get_number(0), config)
+    refactors[refactor](vim.api.nvim_get_current_buf(), config)
 end
 
 function M.get_refactors()

--- a/lua/refactoring/init.lua
+++ b/lua/refactoring/init.lua
@@ -25,8 +25,6 @@ function M.refactor(name, opts)
         )
     end
 
-    -- Remove the calls to vim.fn
-    -- I just forgot the name of this ;)
     local config = Config.get():merge(opts)
     refactors[refactor](vim.api.nvim_get_current_buf(), config)
 end

--- a/lua/refactoring/lsp.lua
+++ b/lua/refactoring/lsp.lua
@@ -16,7 +16,7 @@ function LspDefinition:from_cursor(bufnr, ts_query)
     local definition = lsp_utils.get_definition_under_cursor(bufnr)
 
     local definition_region =
-        Region:from_lsp_range(definition.targetRange or definition.range)
+        Region:from_lsp_range_insert(definition.targetRange or definition.range)
     local declarator_node = ts_query:get_scope_over_region(
         definition_region,
         Query.query_type.Declarator

--- a/lua/refactoring/lsp_utils.lua
+++ b/lua/refactoring/lsp_utils.lua
@@ -20,24 +20,28 @@ end
 
 ---@param pointOrRegion RefactorRegion|RefactorPoint
 ---@param text string
----@param opts table
+---@param opts {below: boolean, _end: boolean}|nil
 ---@return LspTextEdit
 function M.insert_new_line_text(pointOrRegion, text, opts)
     opts = opts or {
         below = true,
+        _end = true,
     }
 
     local region = to_region(pointOrRegion)
 
-    -- what is after?  I just assume 10000 is equivalent
     if opts.below then
-        region.start_col = 10000
-        region.end_col = 10000
         text = code.new_line() .. text
     else
-        region.start_col = 1
-        region.end_col = 0
         text = text .. code.new_line()
+    end
+    -- what is after?  I just assume 10000 is equivalent
+    if opts._end then
+        region.start_col = 10000
+        region.end_col = 10000
+    else
+        region.start_col = 1
+        region.end_col = 1
     end
     return region:to_lsp_text_edit_insert(text)
 end

--- a/lua/refactoring/pipeline/init.lua
+++ b/lua/refactoring/pipeline/init.lua
@@ -11,12 +11,16 @@ local async = require("plenary.async")
 local Pipeline = {}
 Pipeline.__index = Pipeline
 
+---@param task fun(): boolean, any
+---@return RefactorPipeline
 function Pipeline:from_task(task)
     return setmetatable({
         _tasks = { task },
     }, self)
 end
 
+---@param task function
+---@return RefactorPipeline
 function Pipeline:add_task(task)
     table.insert(self._tasks, task)
     return self
@@ -44,6 +48,9 @@ function Pipeline:after(pipeline)
     return self
 end
 
+---@param cb function|nil
+---@param err function|nil
+---@param seed_value any|nil
 function Pipeline:run(cb, err, seed_value)
     err = err or error
     async.void(function()

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -499,6 +499,7 @@ local function extract_setup(refactor)
             function_code,
             { below = true }
         )
+        extract_function.bufnr = refactor.buffers[2]
     end
 
     -- NOTE: there is going to be a bunch of edge cases we haven't thought

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -492,14 +492,14 @@ local function extract_setup(refactor)
         extract_function = lsp_utils.insert_new_line_text(
             region_above_scope,
             function_code,
-            { below = true }
+            { below = true, _end = true }
         )
     else
-        extract_function = {
-            region = region_above_scope,
-            text = function_code,
-            bufnr = refactor.buffers[2],
-        }
+        extract_function = lsp_utils.insert_new_line_text(
+            region_above_scope,
+            function_code,
+            { below = true }
+        )
     end
 
     -- NOTE: there is going to be a bunch of edge cases we haven't thought

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -440,7 +440,6 @@ local function extract_setup(refactor)
     if not function_name or function_name == "" then
         return false, "Error: Must provide function name"
     end
-    assert(function_name)
     local function_body = refactor.region:get_text()
 
     -- NOTE: How do we think about this if we have to pass through multiple

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -42,9 +42,10 @@ local function get_return_vals(refactor)
     local refs = refactor.ts:get_references(refactor.scope)
     refs = utils.after_region(refs, refactor.region)
 
-    local region_var_map = utils.node_text_to_set(region_vars)
+    local bufnr = refactor.buffers[1]
+    local region_var_map = utils.node_text_to_set(bufnr, region_vars)
 
-    local ref_map = utils.node_text_to_set(refs)
+    local ref_map = utils.node_text_to_set(bufnr, refs)
     local return_vals =
         vim.tbl_keys(utils.table_key_intersect(region_var_map, ref_map))
     table.sort(return_vals)
@@ -385,8 +386,9 @@ local function get_selected_locals(refactor, is_class)
         end
     end
 
-    local local_def_map = utils.node_text_to_set(local_defs)
-    local region_refs_map = utils.node_text_to_set(region_refs)
+    local bufnr = refactor.buffers[1]
+    local local_def_map = utils.node_text_to_set(bufnr, local_defs)
+    local region_refs_map = utils.node_text_to_set(bufnr, region_refs)
     return utils.table_key_intersect(local_def_map, region_refs_map)
 end
 

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -441,7 +441,7 @@ end
 --- @return boolean, Refactor|string
 local function extract_setup(refactor)
     local function_name = get_input("106: Extract Function Name > ")
-    if not function_name then
+    if not function_name or function_name == "" then
         return false, "Error: Must provide function name"
     end
     assert(function_name)
@@ -550,6 +550,8 @@ local function ensure_code_gen_106(refactor)
     return ensure_code_gen(refactor, list)
 end
 
+---@param bufnr integer
+---@param opts c|Config
 M.extract_to_file = function(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     get_extract_setup_pipeline(bufnr, opts)
@@ -560,6 +562,8 @@ M.extract_to_file = function(bufnr, opts)
         :run(nil, vim.notify)
 end
 
+---@param bufnr integer
+---@param opts c|Config
 M.extract = function(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     get_extract_setup_pipeline(bufnr, opts)
@@ -580,6 +584,8 @@ M.extract = function(bufnr, opts)
         :run(nil, vim.notify)
 end
 
+---@param bufnr integer
+---@param opts c|Config
 M.extract_block = function(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     Pipeline:from_task(refactor_setup(bufnr, opts))
@@ -590,6 +596,8 @@ M.extract_block = function(bufnr, opts)
         :run(nil, vim.notify)
 end
 
+---@param bufnr integer
+---@param opts c|Config
 M.extract_block_to_file = function(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     Pipeline:from_task(refactor_setup(bufnr, opts))

--- a/lua/refactoring/refactor/119.lua
+++ b/lua/refactoring/refactor/119.lua
@@ -64,6 +64,7 @@ local function get_var_name(var_name, refactor)
 end
 
 ---@param refactor Refactor
+---@return boolean, Refactor|string
 local function extract_var_setup(refactor)
     local extract_node = refactor.region_node
 
@@ -88,7 +89,9 @@ local function extract_var_setup(refactor)
     utils.sort_in_appearance_order(actual_occurrences)
 
     local var_name = get_input("119: What is the var name > ")
-    assert(var_name ~= "", "Error: Must provide new var name")
+    if not var_name then
+        return false, "Error: Must provide new var name"
+    end
 
     refactor.text_edits = {}
     for _, occurrence in pairs(actual_occurrences) do
@@ -105,14 +108,14 @@ local function extract_var_setup(refactor)
 
     -- TODO: Add test for block_scope being nil
     if block_scope == nil then
-        error("block_scope is nil! Something went wrong")
+        return false, "block_scope is nil! Something went wrong"
     end
 
     local unfiltered_statements = refactor.ts:get_statements(block_scope)
 
     -- TODO: Add test for unfiltered_statements being nil
     if #unfiltered_statements < 1 then
-        error("unfiltered_statements is nil! Something went wrong")
+        return false, "unfiltered_statements is nil! Something went wrong"
     end
 
     local statements = vim.tbl_filter(function(node)
@@ -122,7 +125,7 @@ local function extract_var_setup(refactor)
 
     -- TODO: Add test for statements being nil
     if #statements < 1 then
-        error("statements is nil! Something went wrong")
+        return false, "statements is nil! Something went wrong"
     end
 
     local contained = nil
@@ -134,9 +137,8 @@ local function extract_var_setup(refactor)
     end
 
     if not contained then
-        error(
+        return false,
             "Extract var unable to determine its containing statement within the block scope, please post issue with exact highlight + code!  Thanks"
-        )
     end
 
     local region = utils.region_one_line_up_from_node(contained)
@@ -145,6 +147,7 @@ local function extract_var_setup(refactor)
         region = region,
         text = get_new_var_text(extract_node_text, refactor, var_name, region),
     })
+    return true, refactor
 end
 
 ---@param refactor Refactor
@@ -156,22 +159,11 @@ end
 
 function M.extract_var(bufnr, config)
     Pipeline:from_task(refactor_setup(bufnr, config))
-        :add_task(
-            ---@param refactor Refactor
-            function(refactor)
-                return ensure_code_gen_119(refactor)
-            end
-        )
+        :add_task(ensure_code_gen_119)
         :add_task(selection_setup)
-        :add_task(
-            ---@param refactor Refactor
-            function(refactor)
-                extract_var_setup(refactor)
-                return true, refactor
-            end
-        )
+        :add_task(extract_var_setup)
         :after(post_refactor.post_refactor)
-        :run()
+        :run(nil, vim.notify)
 end
 
 return M

--- a/lua/refactoring/refactor/119.lua
+++ b/lua/refactoring/refactor/119.lua
@@ -89,7 +89,7 @@ local function extract_var_setup(refactor)
     utils.sort_in_appearance_order(actual_occurrences)
 
     local var_name = get_input("119: What is the var name > ")
-    if not var_name then
+    if not var_name or var_name == "" then
         return false, "Error: Must provide new var name"
     end
 

--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -8,7 +8,6 @@ local post_refactor = require("refactoring.tasks.post_refactor")
 local refactor_setup = require("refactoring.tasks.refactor_setup")
 local selection_setup = require("refactoring.tasks.selection_setup")
 local get_select_input = require("refactoring.get_select_input")
--- local ts_utils = require("refactoring.utils")
 
 local lsp_utils = require("refactoring.lsp_utils")
 

--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -8,7 +8,7 @@ local post_refactor = require("refactoring.tasks.post_refactor")
 local refactor_setup = require("refactoring.tasks.refactor_setup")
 local selection_setup = require("refactoring.tasks.selection_setup")
 local get_select_input = require("refactoring.get_select_input")
-local ts_utils = require("refactoring.utils")
+-- local ts_utils = require("refactoring.utils")
 
 local lsp_utils = require("refactoring.lsp_utils")
 
@@ -154,7 +154,7 @@ local function inline_var_setup(refactor, bufnr)
             bufnr
         )
 
-        local insert_text, delete_text = lsp_utils.replace_text(
+        local insert_text = lsp_utils.replace_text(
             Region:from_node(declarator_node, bufnr),
             refactor.code.constant({
                 multiple = true,
@@ -164,7 +164,6 @@ local function inline_var_setup(refactor, bufnr)
         )
 
         table.insert(text_edits, insert_text)
-        table.insert(text_edits, delete_text)
     end
 
     local value_text = vim.treesitter.get_node_text(value_node_to_inline, bufnr)
@@ -172,18 +171,10 @@ local function inline_var_setup(refactor, bufnr)
     for _, ref in pairs(references) do
         -- TODO: In my mind, if nothing is left on the line when you remove, it should get deleted.
         -- Could be done via opts into replace_text.
-        local insert_text, delete_text =
+        local insert_text =
             lsp_utils.replace_text(Region:from_node(ref), value_text)
 
-        -- special case: if the identifier we are inlining has only one character, converting to an LSP
-        -- range breaks the whole thing so we have to manually reset it
-        if (ts_utils.get_node_text(node_to_inline)[1]):len() == 1 then
-            insert_text["range"]["end"]["character"] = insert_text["range"]["end"]["character"]
-                + 1
-        end
-
         table.insert(text_edits, insert_text)
-        table.insert(text_edits, delete_text)
     end
 
     refactor.text_edits = text_edits

--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -50,9 +50,7 @@ end
 local function get_node_to_inline(identifiers, bufnr)
     local node_to_inline, identifier_pos
 
-    if #identifiers == 0 then
-        error("No declarations in selected area")
-    elseif #identifiers == 1 then
+    if #identifiers == 1 then
         identifier_pos = 1
         node_to_inline = identifiers[identifier_pos]
     else
@@ -117,6 +115,9 @@ local function inline_var_setup(refactor, bufnr)
         definition = ts.find_definition(node_to_inline, bufnr)
         identifier_pos = determine_identifier_position(identifiers, definition)
     else
+        if #identifiers == 0 then
+            return false, "No declarations in selected area"
+        end
         node_to_inline, identifier_pos = get_node_to_inline(identifiers, bufnr)
         definition = ts.find_definition(node_to_inline, bufnr)
     end
@@ -186,6 +187,7 @@ local function inline_var_setup(refactor, bufnr)
     end
 
     refactor.text_edits = text_edits
+    return true, refactor
 end
 
 ---@param bufnr number
@@ -195,12 +197,11 @@ function M.inline_var(bufnr, opts)
         :add_task(
             --- @param refactor Refactor
             function(refactor)
-                inline_var_setup(refactor, bufnr)
-                return true, refactor
+                return inline_var_setup(refactor, bufnr)
             end
         )
         :after(post_refactor.post_refactor)
-        :run()
+        :run(nil, vim.notify)
 end
 
 return M

--- a/lua/refactoring/region.lua
+++ b/lua/refactoring/region.lua
@@ -79,7 +79,6 @@ function Region:from_node(node, bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     local start_line, start_col, end_line, end_col = node:range()
 
-    -- TODO: is col correct?
     return setmetatable({
         bufnr = bufnr,
         start_row = start_line + 1,
@@ -142,7 +141,8 @@ function Region:to_ts_node(root)
     return root:named_descendant_for_range(s_row, s_col, e_row, e_col)
 end
 
---- Convert a region to a tree sitter region
+--- Convert a region to a treesitter region
+---@return integer start_row, integer start_col, integer end_row, integer end_col
 function Region:to_ts()
     -- Need the -2 for end_col to be  correct for `ts_utils.is_in_node_range`
     -- function results when checking scope for languages like python
@@ -154,6 +154,7 @@ function Region:to_ts()
 end
 
 --- Get the lines contained in the region
+---@return string[]
 function Region:get_lines()
     local text = vim.api.nvim_buf_get_lines(
         self.bufnr,
@@ -165,15 +166,18 @@ function Region:get_lines()
 end
 
 --- Get the left boundary of the region
+---@return RefactorPoint
 function Region:get_start_point()
     return Point:from_values(self.start_row, self.start_col)
 end
 
 --- Get the right boundary of the region
+---@return RefactorPoint
 function Region:get_end_point()
     return Point:from_values(self.end_row, self.end_col)
 end
 
+---@return string[]
 function Region:get_text()
     local text = vim.api.nvim_buf_get_lines(
         self.bufnr,
@@ -201,7 +205,7 @@ end
 ---@field start LspPoint
 ---@field end LspPoint
 
---- Convert a region to an LSP Range
+--- Convert a region to an LSP Range inteded to be used to insert text (start and end should the same despite end being exclusive)
 ---@return LspRange
 function Region:to_lsp_range_insert()
     return {
@@ -216,7 +220,7 @@ function Region:to_lsp_range_insert()
     }
 end
 
---- Convert a region to an LSP Range
+--- Convert a region to an LSP Range intended to be used to replace text (end should be exclusive)
 ---@return LspRange
 function Region:to_lsp_range_replace()
     return {
@@ -267,6 +271,7 @@ end
 
 --- Returns true if self contains region.
 ---@param region RefactorRegion
+---@return boolean
 function Region:contains(region)
     if region.bufnr ~= self.bufnr then
         return false
@@ -278,12 +283,14 @@ end
 
 --- Returns true if self contains point.
 ---@param point RefactorPoint
+---@return boolean
 function Region:contains_point(point)
     return self:get_start_point():leq(point) and self:get_end_point():geq(point)
 end
 
 --- Return true if the position of self lies after the position of region
 ---@param region RefactorRegion
+---@return boolean
 function Region:is_after(region)
     return self:get_start_point():gt(region:get_end_point())
 end

--- a/lua/refactoring/tasks/apply_text_edits.lua
+++ b/lua/refactoring/tasks/apply_text_edits.lua
@@ -11,7 +11,7 @@ local function refactor_apply_text_edits(refactor)
     local edits = {}
 
     for _, edit in pairs(refactor.text_edits) do
-        local bufnr = refactor.buffers[1]
+        local bufnr = edit.bufnr or refactor.buffers[1]
         if not edits[bufnr] then
             edits[bufnr] = {}
         end

--- a/lua/refactoring/tasks/apply_text_edits.lua
+++ b/lua/refactoring/tasks/apply_text_edits.lua
@@ -16,8 +16,6 @@ local function refactor_apply_text_edits(refactor)
             edits[bufnr] = {}
         end
 
-        -- TODO: We should think of a way to make this work with better for both
-        -- new line auto additions and just lsp generated content
         table.insert(edits[bufnr], edit)
         add_change(
             -- TODO (TheLeoP): Probably this is wrong and I should evaluate whether to insert or replace x2

--- a/lua/refactoring/tasks/apply_text_edits.lua
+++ b/lua/refactoring/tasks/apply_text_edits.lua
@@ -27,10 +27,18 @@ local function refactor_apply_text_edits(refactor)
         -- new line auto additions and just lsp generated content
         if edit.newText then
             table.insert(edits[bufnr], edit)
-            add_change(Region:from_lsp_range(edit.range, bufnr), edit.newText)
+            add_change(
+                -- TODO (TheLeoP): Probably this is wrong and I should evaluate whether to insert or replace x2
+                Region:from_lsp_range_insert(edit.range, bufnr),
+                edit.newText
+            )
         else
             local newText = get_text(edit)
-            table.insert(edits[bufnr], edit.region:to_lsp_text_edit(newText))
+            table.insert(
+                edits[bufnr],
+                -- TODO (TheLeoP): Probably this is wrong and I should evaluate whether to insert or replace
+                edit.region:to_lsp_text_edit_insert(newText)
+            )
             add_change(edit.region, newText)
         end
     end

--- a/lua/refactoring/tasks/apply_text_edits.lua
+++ b/lua/refactoring/tasks/apply_text_edits.lua
@@ -1,13 +1,6 @@
 local add_change = require("refactoring.tasks.adjust_cursor").add_change
 local Region = require("refactoring.region")
 
-local function get_text(edit)
-    if edit.add_newline or edit.add_newline == nil then
-        return string.format("\n%s", edit.text)
-    end
-    return edit.text
-end
-
 ---@param refactor Refactor
 ---@return true, Refactor
 local function refactor_apply_text_edits(refactor)
@@ -18,29 +11,19 @@ local function refactor_apply_text_edits(refactor)
     local edits = {}
 
     for _, edit in pairs(refactor.text_edits) do
-        local bufnr = edit.bufnr or refactor.buffers[1]
+        local bufnr = refactor.buffers[1]
         if not edits[bufnr] then
             edits[bufnr] = {}
         end
 
         -- TODO: We should think of a way to make this work with better for both
         -- new line auto additions and just lsp generated content
-        if edit.newText then
-            table.insert(edits[bufnr], edit)
-            add_change(
-                -- TODO (TheLeoP): Probably this is wrong and I should evaluate whether to insert or replace x2
-                Region:from_lsp_range_insert(edit.range, bufnr),
-                edit.newText
-            )
-        else
-            local newText = get_text(edit)
-            table.insert(
-                edits[bufnr],
-                -- TODO (TheLeoP): Probably this is wrong and I should evaluate whether to insert or replace
-                edit.region:to_lsp_text_edit_insert(newText)
-            )
-            add_change(edit.region, newText)
-        end
+        table.insert(edits[bufnr], edit)
+        add_change(
+            -- TODO (TheLeoP): Probably this is wrong and I should evaluate whether to insert or replace x2
+            Region:from_lsp_range_insert(edit.range, bufnr),
+            edit.newText
+        )
     end
 
     for bufnr, edit_set in pairs(edits) do

--- a/lua/refactoring/tasks/apply_text_edits.lua
+++ b/lua/refactoring/tasks/apply_text_edits.lua
@@ -17,11 +17,13 @@ local function refactor_apply_text_edits(refactor)
         end
 
         table.insert(edits[bufnr], edit)
-        add_change(
-            -- TODO (TheLeoP): Probably this is wrong and I should evaluate whether to insert or replace x2
-            Region:from_lsp_range_insert(edit.range, bufnr),
-            edit.newText
-        )
+        local region
+        if edit.range["end"] == edit.range["start"] then
+            region = Region:from_lsp_range_replace(edit.range, bufnr)
+        else
+            region = Region:from_lsp_range_insert(edit.range, bufnr)
+        end
+        add_change(region, edit.newText)
     end
 
     for bufnr, edit_set in pairs(edits) do

--- a/lua/refactoring/tasks/create_file.lua
+++ b/lua/refactoring/tasks/create_file.lua
@@ -3,9 +3,12 @@ local get_input = require("refactoring.get_input")
 local M = {}
 
 ---@param refactor Refactor
+---@return boolean, Refactor|string
 function M.from_input(refactor)
     local file_name = get_input("Create File: Name > ", vim.fn.expand("%:h"))
-    assert(file_name ~= "", "Error: Must provide a file name")
+    if not file_name then
+        return false, "Error: Must provide a file name"
+    end
     -- OPTIONS? We should probably configure this
     -- extract on second method added
     vim.cmd(":vnew")

--- a/lua/refactoring/tasks/create_file.lua
+++ b/lua/refactoring/tasks/create_file.lua
@@ -6,7 +6,7 @@ local M = {}
 ---@return boolean, Refactor|string
 function M.from_input(refactor)
     local file_name = get_input("Create File: Name > ", vim.fn.expand("%:h"))
-    if not file_name then
+    if not file_name or file_name == "" then
         return false, "Error: Must provide a file name"
     end
     -- OPTIONS? We should probably configure this

--- a/lua/refactoring/tasks/ensure_code_gen.lua
+++ b/lua/refactoring/tasks/ensure_code_gen.lua
@@ -1,16 +1,15 @@
 --- @param refactor Refactor
 ---@param code_gen_operations string[]
----@return boolean, Refactor
+---@return boolean, Refactor|string
 local function ensure_code_gen(refactor, code_gen_operations)
     for _, code_gen_operation in ipairs(code_gen_operations) do
         if refactor.code[code_gen_operation] == nil then
-            error(
+            return false,
                 string.format(
                     "No %s function for code generator for %s",
                     code_gen_operation,
                     refactor.filetype
                 )
-            )
         end
     end
     return true, refactor

--- a/lua/refactoring/tasks/refactor_setup.lua
+++ b/lua/refactoring/tasks/refactor_setup.lua
@@ -9,7 +9,7 @@ local Point = require("refactoring.point")
 
 ---
 ---@param input_bufnr number
----@param config Config
+---@param config c|Config
 ---@return function
 local function refactor_setup(input_bufnr, config)
     input_bufnr = input_bufnr or vim.api.nvim_get_current_buf()
@@ -35,16 +35,15 @@ local function refactor_setup(input_bufnr, config)
         ---@field region? RefactorRegion
         ---@field region_node? TSNode
         ---@field scope? TSNode
-        ---@field cursor_col_adjustment? number
-        ---@field text_edits? {add_newline: boolean, region: RefactorRegion, text: string} | LspRange
+        ---@field cursor_col_adjustment? integer
+        ---@field text_edits? {add_newline: boolean, region: RefactorRegion, text: string}[] | LspTextEdit[]
         ---@field code code_generation
         local refactor = {
-            ---@type {cursor: number, highlight_start?: number, highlight_end?: number, func_call?: number}
+            ---@type {cursor: integer, highlight_start?: integer, highlight_end?: integer, func_call?: integer}
             whitespace = {
                 cursor = vim.fn.indent(cursor.row),
             },
             cursor = cursor,
-            highlight_start_col = vim.fn.col("'<"),
             code = config:get_code_generation_for(filetype),
             ts = TreeSitter.get_treesitter(),
             filetype = filetype,

--- a/lua/refactoring/tasks/refactor_setup.lua
+++ b/lua/refactoring/tasks/refactor_setup.lua
@@ -10,12 +10,11 @@ local Point = require("refactoring.point")
 ---
 ---@param input_bufnr number
 ---@param config c|Config
----@return function
+---@return fun(): true, Refactor
 local function refactor_setup(input_bufnr, config)
     input_bufnr = input_bufnr or vim.api.nvim_get_current_buf()
     config = config or Config.get()
 
-    --- @retun boolean, Refactor
     return function()
         -- Setting bufnr to test bufnr
         local bufnr

--- a/lua/refactoring/tasks/refactor_setup.lua
+++ b/lua/refactoring/tasks/refactor_setup.lua
@@ -36,7 +36,7 @@ local function refactor_setup(input_bufnr, config)
         ---@field region_node? TSNode
         ---@field scope? TSNode
         ---@field cursor_col_adjustment? integer
-        ---@field text_edits? {add_newline: boolean, region: RefactorRegion, text: string}[] | LspTextEdit[]
+        ---@field text_edits? LspTextEdit[]
         ---@field code code_generation
         local refactor = {
             ---@type {cursor: integer, highlight_start?: integer, highlight_end?: integer, func_call?: integer}

--- a/lua/refactoring/tasks/refactor_setup.lua
+++ b/lua/refactoring/tasks/refactor_setup.lua
@@ -35,7 +35,7 @@ local function refactor_setup(input_bufnr, config)
         ---@field region_node? TSNode
         ---@field scope? TSNode
         ---@field cursor_col_adjustment? integer
-        ---@field text_edits? LspTextEdit[]
+        ---@field text_edits? LspTextEdit[] | {bufnr: integer|nil}[]
         ---@field code code_generation
         local refactor = {
             ---@type {cursor: integer, highlight_start?: integer, highlight_end?: integer, func_call?: integer}

--- a/lua/refactoring/tests/lsp_utils_spec.lua
+++ b/lua/refactoring/tests/lsp_utils_spec.lua
@@ -49,9 +49,6 @@ describe("lsp_utils", function()
         }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
     end)
 
-    -- TODO: Genuinely think that this could be a bug within neovim.  I cannot
-    -- set the end col = start col or else it will consume the starting
-    -- character
     it("should insert text.", function()
         setup()
         test_utils.vim_motion("2jfbviw")
@@ -71,7 +68,7 @@ describe("lsp_utils", function()
         setup()
         test_utils.vim_motion("2jfbviw")
         local region = Region:from_current_selection()
-        local insert_text, delete_text = lsp_utils.replace_text(
+        local insert_text = lsp_utils.replace_text(
             region,
             [[
 
@@ -80,11 +77,7 @@ bin, ban,]]
         )
 
         local bufnr = vim.api.nvim_get_current_buf()
-        vim.lsp.util.apply_text_edits(
-            { insert_text, delete_text },
-            bufnr,
-            "utf-16"
-        )
+        vim.lsp.util.apply_text_edits({ insert_text }, bufnr, "utf-16")
 
         assert.are.same({
             "foo",

--- a/lua/refactoring/tests/refactor_spec.lua
+++ b/lua/refactoring/tests/refactor_spec.lua
@@ -51,6 +51,8 @@ local function for_each_file(cb)
 end
 
 local function test_empty_input()
+    -- TODO (TheLeoP): does this make sense?
+    vim.notify = error
     local test_cases = {
         [1] = {
             ["inputs"] = "",

--- a/lua/refactoring/tests/region_spec.lua
+++ b/lua/refactoring/tests/region_spec.lua
@@ -36,7 +36,7 @@ describe("Region", function()
         -- TODO: Why is first selection just not present...
         vim.cmd(":1")
         vim_motion("jwvje")
-        eq("n", vim.fn.mode())
+        eq("n", vim.api.nvim_get_mode().mode)
         eq(3, vim.fn.line("."))
         local region = Region:from_current_selection()
         eq({ "(true) {", "    bar" }, region:get_text())

--- a/lua/refactoring/treesitter/langs/go.lua
+++ b/lua/refactoring/treesitter/langs/go.lua
@@ -22,6 +22,7 @@ function Golang.new(bufnr, ft)
         scope_names = {
             function_declaration = "function",
             method_declaration = "function",
+            func_literal = "function",
             method = "program",
         },
         valid_class_nodes = {
@@ -65,6 +66,7 @@ function Golang.new(bufnr, ft)
             InlineNode("(if_statement) @tmp_capture"),
             InlineNode("(for_statement) @tmp_capture"),
             InlineNode("(call_expression) @tmp_capture"),
+            InlineNode("(assignment_statement) @tmp_capture"),
         },
         parameter_list = {
             InlineNode(

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -213,7 +213,7 @@ function TreeSitter:get_class_type(scope)
 end
 
 ---@param node TSNode
----@param container_map table
+---@param container_map table|number|string
 ---@return TSNode|nil
 local function containing_node_by_type(node, container_map)
     if not node then
@@ -225,6 +225,7 @@ local function containing_node_by_type(node, container_map)
         container_map = { container_map = true }
     end
 
+    -- TODO (TheLeoP): fix: if multiple containing nodes have the same type, this returns the first match, not necesarily the containing node (example: golang "block")
     repeat
         if container_map[node:type()] ~= nil then
             break
@@ -233,7 +234,7 @@ local function containing_node_by_type(node, container_map)
     -- This statement can be uncommented to print all the parent nodes of the
     -- current node until there are no more. Useful in finding certain nodes
     -- like the global scope node, which doesn't show up in playground.
-    -- print(node:type())
+    -- vim.print({ type = node:type(), container_map })
     until node == nil
 
     return node

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -182,9 +182,13 @@ function TreeSitter:get_references(scope)
     return out
 end
 
+---@param scope TSNode
+---@param region RefactorRegion
+---@return TSNode[]
 function TreeSitter:get_region_refs(scope, region)
     local nodes = self:get_references(scope)
-    nodes = utils.region_intersect(nodes, region)
+
+    nodes = utils.region_intersect(nodes, region, region.bufnr)
     return nodes
 end
 

--- a/lua/refactoring/ts.lua
+++ b/lua/refactoring/ts.lua
@@ -11,7 +11,7 @@ end
 
 ---@param node TSNode
 ---@param bufnr integer
----@return TSNode
+---@return TSNode, TSNode
 M.find_definition = function(node, bufnr)
     return ts_locals.find_definition(node, bufnr)
 end

--- a/lua/refactoring/ts.lua
+++ b/lua/refactoring/ts.lua
@@ -3,14 +3,24 @@ local ts_utils = require("nvim-treesitter.ts_utils")
 
 local M = {}
 
+---@param win integer
+---@return TSNode
 M.get_node_at_cursor = function(win)
     return ts_utils.get_node_at_cursor(win)
 end
 
+---@param node TSNode
+---@param bufnr integer
+---@return TSNode
 M.find_definition = function(node, bufnr)
     return ts_locals.find_definition(node, bufnr)
 end
 
+---@param node TSNode
+---@param scope TSNode|nil
+---@param bufnr integer
+---@param definition TSNode|nil
+---@return TSNode[]
 M.find_references = function(node, scope, bufnr, definition)
     if not definition then
         definition = M.find_definition(node, bufnr)

--- a/lua/refactoring/utils.lua
+++ b/lua/refactoring/utils.lua
@@ -54,7 +54,7 @@ end
 ---@return RefactorRegion
 function M.get_top_of_file_region()
     local range = { line = 0, character = 0 }
-    return Region:from_lsp_range({ start = range, ["end"] = range })
+    return Region:from_lsp_range_insert({ start = range, ["end"] = range })
 end
 
 -- FROM http://lua-users.org/wiki/CommonFunctions
@@ -217,11 +217,12 @@ end
 ---@param node TSNode
 function M.region_above_node(node)
     local scope_region = Region:from_node(node)
-    local lsp_range = scope_region:to_lsp_range()
+    -- TODO (TheLeoP): should I create a special case for this?
+    local lsp_range = scope_region:to_lsp_range_insert()
     lsp_range.start.line = math.max(lsp_range.start.line - 1, 0)
     lsp_range.start.character = 0
     lsp_range["end"] = lsp_range.start
-    return Region:from_lsp_range(lsp_range)
+    return Region:from_lsp_range_insert(lsp_range)
 end
 
 return M

--- a/lua/refactoring/utils.lua
+++ b/lua/refactoring/utils.lua
@@ -30,6 +30,9 @@ function M.take_one(table, fn)
     return out
 end
 
+---@param inputstr string
+---@param sep string
+---@return string[]
 function M.split_string(inputstr, sep)
     local t = {}
     -- [[ lets not think about the edge case there... --]]
@@ -48,6 +51,7 @@ function M.split_string(inputstr, sep)
     return t
 end
 
+---@return RefactorRegion
 function M.get_top_of_file_region()
     local range = { line = 0, character = 0 }
     return Region:from_lsp_range({ start = range, ["end"] = range })
@@ -66,6 +70,8 @@ function M.trim(s)
     return (s:gsub("^%s*(.-)%s*$", "%1"))
 end
 
+---@param node TSNode
+---@param out string[]|nil
 function M.get_node_text(node, out)
     out = out or {}
     local count = node:child_count()
@@ -106,6 +112,8 @@ function M.appears_before(a, b)
     return (a_col < b_col or b_col + b_bytes > a_col + a_bytes)
 end
 
+---@param nodes TSNode[]
+---@return TSNode[]
 function M.sort_in_appearance_order(nodes)
     table.sort(nodes, M.appears_before)
     return nodes
@@ -131,6 +139,7 @@ function M.node_contains(a, b)
 end
 
 -- TODO: This likely doesn't work with multistatement line inserts
+---@param node TSNode
 function M.region_one_line_up_from_node(node)
     local region = Region:from_node(node)
     region.end_row = region.start_row
@@ -139,24 +148,35 @@ function M.region_one_line_up_from_node(node)
     return region
 end
 
+---@param nodes TSNode[]
+---@param region RefactorRegion
+---@return TSNode[]
 M.region_complement = function(nodes, region)
     return vim.tbl_filter(function(node)
         return not region:contains(Region:from_node(node))
     end, nodes)
 end
 
+---@param nodes TSNode[]
+---@param region RefactorRegion
+---@return TSNode[]
 M.region_intersect = function(nodes, region)
     return vim.tbl_filter(function(node)
         return region:contains(Region:from_node(node))
     end, nodes)
 end
 
+---@param nodes TSNode[]
+---@param region RefactorRegion
+---@return TSNode[]
 M.after_region = function(nodes, region)
     return vim.tbl_filter(function(node)
         return Region:from_node(node):is_after(region)
     end, nodes)
 end
 
+---@param t table
+---@return boolean
 function M.table_has_keys(t)
     for _ in pairs(t) do
         return true
@@ -181,6 +201,9 @@ function M.node_text_to_set(...)
     return out
 end
 
+---@param a table
+---@param b table
+---@return table
 function M.table_key_intersect(a, b)
     local out = {}
     for k, v in pairs(b) do

--- a/lua/refactoring/utils.lua
+++ b/lua/refactoring/utils.lua
@@ -186,9 +186,8 @@ end
 
 -- TODO: Very unsure if this needs to be a "util" or not But this is super
 -- useful in refactor 106 and I assume it will be used elsewhere quite a bit
-function M.node_text_to_set(...)
+function M.node_text_to_set(bufnr, ...)
     local out = {}
-    local bufnr = vim.api.nvim_get_current_buf()
     for i = 1, select("#", ...) do
         local nodes = select(i, ...)
         for _, node in pairs(nodes) do

--- a/lua/refactoring/utils.lua
+++ b/lua/refactoring/utils.lua
@@ -159,10 +159,11 @@ end
 
 ---@param nodes TSNode[]
 ---@param region RefactorRegion
+---@param bufnr integer|nil
 ---@return TSNode[]
-M.region_intersect = function(nodes, region)
+M.region_intersect = function(nodes, region, bufnr)
     return vim.tbl_filter(function(node)
-        return region:contains(Region:from_node(node))
+        return region:contains(Region:from_node(node, bufnr))
     end, nodes)
 end
 

--- a/lua/refactoring/utils.lua
+++ b/lua/refactoring/utils.lua
@@ -216,12 +216,13 @@ end
 ---@param node TSNode
 function M.region_above_node(node)
     local scope_region = Region:from_node(node)
-    -- TODO (TheLeoP): should I create a special case for this?
-    local lsp_range = scope_region:to_lsp_range_insert()
-    lsp_range.start.line = math.max(lsp_range.start.line - 1, 0)
-    lsp_range.start.character = 0
-    lsp_range["end"] = lsp_range.start
-    return Region:from_lsp_range_insert(lsp_range)
+
+    scope_region.start_row = math.max(scope_region.start_row - 1, 1)
+    scope_region.start_col = 1
+    scope_region.end_row = scope_region.start_row
+    scope_region.end_col = scope_region.start_col
+
+    return scope_region
 end
 
 return M

--- a/scripts/minimal.vim
+++ b/scripts/minimal.vim
@@ -32,7 +32,7 @@ runtime! plugin/nvim-treesitter.lua
 lua <<EOF
 -- lsp-config setup
 
--- treeshitter setup
+-- treesitter setup
 local required_parsers = {'c', 'cpp', 'go', 'lua', 'php', 'python', 'typescript', 'javascript', 'java', 'ruby', 'tsx'}
 local installed_parsers = require'nvim-treesitter.info'.installed_parsers()
 local to_install = vim.tbl_filter(function(parser)


### PR DESCRIPTION
This PR fixes #373 (a small change, as described on the issue), uses `Pipeline`  to stop the execution whenever an error occurs (showing the error message via `vim.notify`. Should I add some kind of option to override this?) fixing #358 (if a user doesn't enter a variable name o a file name, the pipeline is stopped and an error message is showed via `vim.notify`) and cleans/refactors some code.

For example, the issue solved by #355 was related to an old workaround on `lsp_utils.lua` (using the same `start` and `end` for an lsp_range used to cause problems. The issue is solved now, so the workaround is no longer needed). As a consecuense of this change, it's possible to differentitate between lsp_ranges where text is going to be inserted and where text is going to be replaced.