### PR TITLE
#fix 279

### DIFF
--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -67,8 +67,10 @@ end
 ---@return table<string, string>
 local function get_function_param_types(refactor, args)
     local args_types = {}
-    local parameter_arg_types =
-        refactor.ts:get_local_parameter_types(refactor.scope)
+    local parameter_arg_types = refactor.ts:get_local_parameter_types(
+        refactor.scope,
+        refactor.ts.argument_type_index
+    )
     for _, arg in pairs(args) do
         local function_param_type
         local curr_arg = refactor.ts.get_arg_type_key(arg)

--- a/lua/refactoring/tests/refactor/106/c/extract-block/extract_block.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/extract-block/extract_block.expected.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-void foo_bar(INSERT_PARAM_TYPE a) {
+void foo_bar(int a) {
   int test = 1, test_other = 1;
 
   for (int idx = test - 1; idx < test_other; idx++) {

--- a/lua/refactoring/tests/refactor/106/c/simple-function/extract.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/simple-function/extract.expected.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-void foo_bar(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
+void foo_bar(int a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
   for (int idx = test - 1; idx < test_other; idx++) {
     printf("%d %d", idx, a);
   }

--- a/lua/refactoring/tests/refactor/106/c/with-comments/extract.expected.c
+++ b/lua/refactoring/tests/refactor/106/c/with-comments/extract.expected.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-void foo_bar(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
+void foo_bar(int a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
   for (int idx = test - 1; idx < test_other; idx++) {
     printf("%d %d", idx, a);
   }

--- a/lua/refactoring/tests/refactor/106/cpp/class-function/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/class-function/extract.expected.cpp
@@ -2,7 +2,7 @@
 
 class Coconut {
 
-void foo(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
+void foo(int a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
     for (int x = 0; x < test_other + test; x++) {
       std::cout << x << " " << a << std::endl;
     }

--- a/lua/refactoring/tests/refactor/106/cpp/extract-block/extract_block.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/extract-block/extract_block.expected.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-void foo_bar(INSERT_PARAM_TYPE a) {
+void foo_bar(int a) {
   int test = 1, test_other = 1;
 
   for (int idx = test - 1; idx < test_other; idx++) {

--- a/lua/refactoring/tests/refactor/106/cpp/simple-function/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/simple-function/extract.expected.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-void foo_bar(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
+void foo_bar(int a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
   for (int idx = test - 1; idx < test_other; idx++) {
     std::cout << idx << " " << a << std::endl;
   }

--- a/lua/refactoring/tests/refactor/106/cpp/with-comments/extract.expected.cpp
+++ b/lua/refactoring/tests/refactor/106/cpp/with-comments/extract.expected.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-void foo_bar(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
+void foo_bar(int a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
   for (int idx = test - 1; idx < test_other; idx++) {
     std::cout << idx << " " << a << std::endl;
   }

--- a/lua/refactoring/tests/refactor/106/java/class-function/extract.expected.java
+++ b/lua/refactoring/tests/refactor/106/java/class-function/extract.expected.java
@@ -1,6 +1,6 @@
 class Extract {
 
-public static void foo(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
+public static void foo(int a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
     for (int x = 0; x < test_other + test; x++) {
       System.out.println(x + " " + a);
     }

--- a/lua/refactoring/tests/refactor/106/java/extract_block/extract_block.expected.java
+++ b/lua/refactoring/tests/refactor/106/java/extract_block/extract_block.expected.java
@@ -1,6 +1,6 @@
 class Extract {
 
-public static void foo_bar(INSERT_PARAM_TYPE a) {
+public static void foo_bar(int a) {
     int test = 1, test_other = 11;
     for (int x = 0; x < test_other + test; x++) {
       System.out.println(x + " " + a);

--- a/lua/refactoring/tests/refactor/106/java/with-comments/extract.expected.java
+++ b/lua/refactoring/tests/refactor/106/java/with-comments/extract.expected.java
@@ -1,6 +1,6 @@
 class Extract {
 
-public static void foo(INSERT_PARAM_TYPE a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
+public static void foo(int a, INSERT_PARAM_TYPE test, INSERT_PARAM_TYPE test_other) {
     for (int x = 0; x < test_other + test; x++) {
       System.out.println(x + " " + a);
     }

--- a/lua/refactoring/tests/refactor_spec.lua
+++ b/lua/refactoring/tests/refactor_spec.lua
@@ -51,7 +51,6 @@ local function for_each_file(cb)
 end
 
 local function test_empty_input()
-    -- TODO (TheLeoP): does this make sense?
     vim.notify = error
     local test_cases = {
         [1] = {

--- a/lua/refactoring/treesitter/langs/c.lua
+++ b/lua/refactoring/treesitter/langs/c.lua
@@ -53,6 +53,11 @@ function C.new(bufnr, ft)
             while_statement = true,
             do_statement = true,
         },
+
+        function_scopes = {
+            function_definition = true,
+            translation_unit = true,
+        },
         debug_paths = {
             class_specifier = FieldNode("name"),
             function_definition = TakeFirstNode(
@@ -75,6 +80,11 @@ function C.new(bufnr, ft)
             InlineNode("(do_statement) @tmp_capture"),
             InlineNode("(while_statement) @tmp_capture"),
             InlineNode("(declaration) @tmp_capture"),
+        },
+        parameter_list = {
+            InlineNode(
+                "(function_declarator parameters:(parameter_list ((parameter_declaration) @tmp_capture)))"
+            ),
         },
         function_body = {
             InlineNode("(compound_statement (_) @tmp_capture)"),

--- a/lua/refactoring/treesitter/langs/c.lua
+++ b/lua/refactoring/treesitter/langs/c.lua
@@ -90,6 +90,7 @@ function C.new(bufnr, ft)
             InlineNode("(compound_statement (_) @tmp_capture)"),
         },
         require_param_types = true,
+        argument_type_index = 1,
     }
     return TreeSitter:new(config, bufnr)
 end

--- a/lua/refactoring/treesitter/langs/cpp.lua
+++ b/lua/refactoring/treesitter/langs/cpp.lua
@@ -96,6 +96,7 @@ function Cpp.new(bufnr, ft)
             InlineNode("(compound_statement) @tmp_capture"),
         },
         require_param_types = true,
+        argument_type_index = 1,
     }
     return TreeSitter:new(config, bufnr)
 end

--- a/lua/refactoring/treesitter/langs/cpp.lua
+++ b/lua/refactoring/treesitter/langs/cpp.lua
@@ -53,6 +53,10 @@ function Cpp.new(bufnr, ft)
             while_statement = true,
             do_statement = true,
         },
+        function_scopes = {
+            function_definition = true,
+            translation_unit = true,
+        },
         debug_paths = {
             class_specifier = FieldNode("name"),
             function_definition = TakeFirstNode(
@@ -81,6 +85,11 @@ function Cpp.new(bufnr, ft)
             InlineNode("(do_statement) @tmp_capture"),
             InlineNode("(while_statement) @tmp_capture"),
             InlineNode("(declaration) @tmp_capture"),
+        },
+        parameter_list = {
+            InlineNode(
+                "(function_declarator parameters:(parameter_list ((parameter_declaration) @tmp_capture)))"
+            ),
         },
         function_body = {
             InlineNode("(compound_statement (_) @tmp_capture)"),

--- a/lua/refactoring/treesitter/langs/java.lua
+++ b/lua/refactoring/treesitter/langs/java.lua
@@ -50,6 +50,9 @@ function Java.new(bufnr, ft)
             while_statement = true,
             do_statement = true,
         },
+        function_scopes = {
+            method_declaration = true,
+        },
         debug_paths = {
             class_declaration = FieldNode("name"),
             method_declaration = TakeFirstNode(
@@ -71,6 +74,11 @@ function Java.new(bufnr, ft)
             InlineNode("(do_statement) @tmp_capture"),
             InlineNode("(while_statement) @tmp_capture"),
             InlineNode("(local_variable_declaration) @tmp_capture"),
+        },
+        parameter_list = {
+            InlineNode(
+                "(method_declaration parameters: (formal_parameters ((formal_parameter) @tmp_capture)))"
+            ),
         },
         function_body = {
             InlineNode("(block (_) @tmp_capture)"),

--- a/lua/refactoring/treesitter/langs/java.lua
+++ b/lua/refactoring/treesitter/langs/java.lua
@@ -86,6 +86,7 @@ function Java.new(bufnr, ft)
         require_class_name = true,
         require_class_type = true,
         require_param_types = true,
+        argument_type_index = 1,
     }
     return TreeSitter:new(config, bufnr)
 end

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -26,6 +26,7 @@ local Region = require("refactoring.region")
 ---@field function_scopes table<string, string|true>: nodes to find a function declaration
 ---@field require_class_name boolean: flag to require class name for codegen
 ---@field require_class_type boolean: flag to require class type for codegen
+---@field argument_type_index 1|2: 1-indexed location of type in function args (int foo= 1, foo int= 2)
 
 --- The following fields act similar to a cursor
 ---@class TreeSitter: TreeSitterLanguageConfig
@@ -57,6 +58,7 @@ function TreeSitter:new(config, bufnr)
         require_class_name = false,
         require_class_type = false,
         require_param_types = false,
+        argument_type_index = 2,
         filetype = config.filetype,
     }
     local c = vim.tbl_extend("force", default_config, config)
@@ -279,8 +281,9 @@ local function containing_node_by_type(node, container_map)
 end
 
 ---@param scope TSNode
+---@param type_index integer
 ---@return table<string, string>
-function TreeSitter:get_local_parameter_types(scope)
+function TreeSitter:get_local_parameter_types(scope, type_index)
     local parameter_types = {}
     self:validate_setting("function_scopes")
     local function_node = containing_node_by_type(scope, self.function_scopes)
@@ -302,7 +305,10 @@ function TreeSitter:get_local_parameter_types(scope)
             local region = Region:from_node(node, self.bufnr)
             local parameter_list = region:get_text()
             local parameter_split = utils.split_string(parameter_list[1], " ")
-            parameter_types[parameter_split[1]] = parameter_split[2]
+
+            local arg_index = type_index == 2 and 1 or 2
+            parameter_types[parameter_split[arg_index]] =
+                parameter_split[type_index]
         end
     end
 

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -278,21 +278,21 @@ local function containing_node_by_type(node, container_map)
     return node
 end
 
--- TODO: Can we validate settings here without breaking things?
 ---@param scope TSNode
 ---@return table<string, string>
 function TreeSitter:get_local_parameter_types(scope)
     local parameter_types = {}
+    self:validate_setting("function_scopes")
     local function_node = containing_node_by_type(scope, self.function_scopes)
 
-    -- TODO: Uncomment this error once validate settings in this func
-    -- if function_node == nil then
-    -- error(
-    -- "Failed to get function_node in get_local_parameter_types, check `function_scopes` queries"
-    -- )
-    -- end
+    if function_node == nil then
+        error(
+            "Failed to get function_node in get_local_parameter_types, check `function_scopes` queries"
+        )
+    end
 
     -- Get parameter list
+    self:validate_setting("parameter_list")
     local parameter_list_nodes =
         self:loop_thru_nodes(function_node, self.parameter_list)
 


### PR DESCRIPTION
Fixes #279 and adds `argument_type_index`  option to TreeSitter instances to define the 1-based index of the type of an argument in a function call (in go (`foo int`) type has index `2`  while in c (`int foo`) type has index `1`). Minor modifycations to some test were made to account for this (C or java now can infer the same types as go)