### PR TITLE
Closes #388

### DIFF
--- a/lua/refactoring/code_generation/init.lua
+++ b/lua/refactoring/code_generation/init.lua
@@ -11,7 +11,7 @@ local php = require("refactoring.code_generation.langs.php")
 local java = require("refactoring.code_generation.langs.java")
 local ruby = require("refactoring.code_generation.langs.ruby")
 
----@type {[string]: code_generation} | {new_line: fun(): string}
+---@type table<string, code_generation>|{new_line: fun(): string}
 local M = {
     javascript = javascript,
     typescript = typescript,

--- a/lua/refactoring/code_generation/init.lua
+++ b/lua/refactoring/code_generation/init.lua
@@ -11,7 +11,7 @@ local php = require("refactoring.code_generation.langs.php")
 local java = require("refactoring.code_generation.langs.java")
 local ruby = require("refactoring.code_generation.langs.ruby")
 
----@type table<string, code_generation>|{new_line: fun(): string}
+---@type table<ft, code_generation>|{new_line: fun(): string}
 local M = {
     javascript = javascript,
     typescript = typescript,

--- a/lua/refactoring/config/init.lua
+++ b/lua/refactoring/config/init.lua
@@ -96,13 +96,13 @@ local default_extract_var_statements = {}
 ---| "ruby"
 
 ---@class ConfigOpts
----@field formatting table<ft, {cmd: string}>|nil
----@field code_generation table<ft, code_generation>|{new_line: fun(): string}|nil
----@field prompt_func_return_type table<ft, boolean>|nil
----@field prompt_func_param_type table<ft, boolean>|nil
----@field printf_statements table<ft, string[]>|nil
----@field print_var_statements table<ft, string[]>|nil
----@field extract_var_statements table<ft, string>|nil
+---@field formatting table<ft, {cmd: string}>
+---@field code_generation table<ft, code_generation>|{new_line: fun(): string}
+---@field prompt_func_return_type table<ft, boolean>
+---@field prompt_func_param_type table<ft, boolean>
+---@field printf_statements table<ft, string[]>
+---@field print_var_statements table<ft, string[]>
+---@field extract_var_statements table<ft, string>
 
 ---@class c: ConfigOpts
 ---@field _automation table

--- a/lua/refactoring/debug/cleanup.lua
+++ b/lua/refactoring/debug/cleanup.lua
@@ -7,7 +7,7 @@ local post_refactor = require("refactoring.tasks.post_refactor")
 local MAX_COL = 100000
 
 local function cleanup(bufnr, config)
-    return Pipeline:from_task(refactor_setup(bufnr, config))
+    Pipeline:from_task(refactor_setup(bufnr, config))
         :add_task(
             ---@param refactor Refactor
             function(refactor)

--- a/lua/refactoring/debug/cleanup.lua
+++ b/lua/refactoring/debug/cleanup.lua
@@ -4,8 +4,6 @@ local Region = require("refactoring.region")
 local lsp_utils = require("refactoring.lsp_utils")
 local post_refactor = require("refactoring.tasks.post_refactor")
 
-local MAX_COL = 100000
-
 local function cleanup(bufnr, config)
     Pipeline:from_task(refactor_setup(bufnr, config))
         :add_task(
@@ -25,27 +23,8 @@ local function cleanup(bufnr, config)
                 end
 
                 for row_num, line in ipairs(lines) do
-                    local region
-                    if row_num ~= 1 then
-                        region = Region:from_values(
-                            bufnr,
-                            row_num - 1,
-                            MAX_COL,
-                            row_num,
-                            MAX_COL
-                        )
-                    else
-                        print(
-                            "NOTE! Can't delete first line of file, leaving blank"
-                        )
-                        region = Region:from_values(
-                            bufnr,
-                            row_num,
-                            1,
-                            row_num,
-                            MAX_COL
-                        )
-                    end
+                    local region =
+                        Region:from_values(bufnr, row_num, 1, row_num + 1, 0)
 
                     if opts.printf then
                         if

--- a/lua/refactoring/debug/cleanup.lua
+++ b/lua/refactoring/debug/cleanup.lua
@@ -23,30 +23,70 @@ local function cleanup(bufnr, config)
                 end
 
                 for row_num, line in ipairs(lines) do
-                    local region =
-                        Region:from_values(bufnr, row_num, 1, row_num + 1, 0)
-
                     if opts.printf then
                         if
-                            string.find(line, "__AUTO_GENERATED_PRINTF__")
+                            string.find(line, "__AUTO_GENERATED_PRINTF_END__")
                             ~= nil
                         then
-                            table.insert(
-                                refactor.text_edits,
-                                lsp_utils.delete_text(region)
-                            )
+                            for searched_row_num = row_num, 1, -1 do
+                                local searched_line = lines[searched_row_num]
+
+                                if
+                                    string.find(
+                                        searched_line,
+                                        "__AUTO_GENERATED_PRINTF_START__"
+                                    )
+                                    ~= nil
+                                then
+                                    local region = Region:from_values(
+                                        bufnr,
+                                        searched_row_num,
+                                        1,
+                                        row_num + 1,
+                                        0
+                                    )
+                                    table.insert(
+                                        refactor.text_edits,
+                                        lsp_utils.delete_text(region)
+                                    )
+                                    break
+                                end
+                            end
                         end
                     end
 
                     if opts.print_var then
                         if
-                            string.find(line, "__AUTO_GENERATED_PRINT_VAR__")
+                            string.find(
+                                line,
+                                "__AUTO_GENERATED_PRINT_VAR_END__"
+                            )
                             ~= nil
                         then
-                            table.insert(
-                                refactor.text_edits,
-                                lsp_utils.delete_text(region)
-                            )
+                            for searched_row_num = row_num, 1, -1 do
+                                local searched_line = lines[searched_row_num]
+
+                                if
+                                    string.find(
+                                        searched_line,
+                                        "__AUTO_GENERATED_PRINT_VAR_START__"
+                                    )
+                                    ~= nil
+                                then
+                                    local region = Region:from_values(
+                                        bufnr,
+                                        searched_row_num,
+                                        1,
+                                        row_num + 1,
+                                        0
+                                    )
+                                    table.insert(
+                                        refactor.text_edits,
+                                        lsp_utils.delete_text(region)
+                                    )
+                                    break
+                                end
+                            end
                         end
                     end
                 end

--- a/lua/refactoring/debug/get_path.lua
+++ b/lua/refactoring/debug/get_path.lua
@@ -3,8 +3,11 @@ local Point = require("refactoring.point")
 local refactor_setup = require("refactoring.tasks.refactor_setup")
 local debug_utils = require("refactoring.debug.debug_utils")
 
+---@param bufnr integer
+---@param config Config
+---@return string out
 local function get_path(bufnr, config)
-    local out = nil
+    local out = nil ---@type string
     Pipeline:from_task(refactor_setup(bufnr, config))
         :add_task(
             ---@param refactor Refactor
@@ -16,11 +19,15 @@ local function get_path(bufnr, config)
                 return true, refactor
             end
         )
-        :run(function(ok, res)
-            if ok then
-                out = res.return_value
+        :run(
+            ---@param ok boolean
+            ---@param res Refactor
+            function(ok, res)
+                if ok then
+                    out = res.return_value
+                end
             end
-        end)
+        )
 
     return out
 end

--- a/lua/refactoring/debug/init.lua
+++ b/lua/refactoring/debug/init.lua
@@ -6,21 +6,26 @@ local cleanup = require("refactoring.debug.cleanup")
 
 local M = {}
 
+---@param opts ConfigOpts
 function M.printf(opts)
     local config = Config.get():merge(opts)
-    return printf(vim.api.nvim_get_current_buf(), config)
+    printf(vim.api.nvim_get_current_buf(), config)
 end
 
+---@param opts ConfigOpts
 function M.print_var(opts)
     local config = Config.get():merge(opts)
-    return print_var(vim.api.nvim_get_current_buf(), config)
+    print_var(vim.api.nvim_get_current_buf(), config)
 end
 
+---@param opts ConfigOpts
 function M.cleanup(opts)
     local config = Config.get():merge(opts)
-    return cleanup(vim.api.nvim_get_current_buf(), config)
+    cleanup(vim.api.nvim_get_current_buf(), config)
 end
 
+---@param opts ConfigOpts
+---@return string
 function M.get_path(opts)
     local config = Config.get():merge(opts)
     return get_path(vim.api.nvim_get_current_buf(), config)

--- a/lua/refactoring/debug/init.lua
+++ b/lua/refactoring/debug/init.lua
@@ -1,6 +1,6 @@
 local Config = require("refactoring.config")
-local printf = require("refactoring.debug.printf")
-local print_var = require("refactoring.debug.print_var")
+local printf = require("refactoring.debug.printf").printDebug
+local print_var = require("refactoring.debug.print_var").printDebug
 local get_path = require("refactoring.debug.get_path")
 local cleanup = require("refactoring.debug.cleanup")
 

--- a/lua/refactoring/init.lua
+++ b/lua/refactoring/init.lua
@@ -5,10 +5,13 @@ local async = require("plenary.async")
 
 local M = {}
 
+---@param config ConfigOpts
 function M.setup(config)
     Config.setup(config)
 end
 
+---@param name string|number
+---@param opts ConfigOpts
 function M.refactor(name, opts)
     if opts == nil then
         opts = {}
@@ -29,10 +32,12 @@ function M.refactor(name, opts)
     refactors[refactor](vim.api.nvim_get_current_buf(), config)
 end
 
+---@return string[]
 function M.get_refactors()
     return vim.tbl_keys(refactors.refactor_names)
 end
 
+---@param opts ConfigOpts
 function M.select_refactor(opts)
     async.run(function()
         local selected_refactor = get_select_input(

--- a/lua/refactoring/init.lua
+++ b/lua/refactoring/init.lua
@@ -11,7 +11,7 @@ function M.setup(config)
 end
 
 ---@param name string|number
----@param opts ConfigOpts
+---@param opts ConfigOpts|nil
 function M.refactor(name, opts)
     if opts == nil then
         opts = {}

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -18,6 +18,9 @@ local M = {}
 
 -- 1.  We need definition set of potential captured variables
 
+---@param bufnr integer
+---@param opts Config
+---@return RefactorPipeline
 local function get_extract_setup_pipeline(bufnr, opts)
     return Pipeline:from_task(refactor_setup(bufnr, opts))
         :add_task(selection_setup)
@@ -583,7 +586,7 @@ local function ensure_code_gen_106(refactor)
 end
 
 ---@param bufnr integer
----@param opts c|Config
+---@param opts Config
 M.extract_to_file = function(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     get_extract_setup_pipeline(bufnr, opts)
@@ -595,7 +598,7 @@ M.extract_to_file = function(bufnr, opts)
 end
 
 ---@param bufnr integer
----@param opts c|Config
+---@param opts Config
 M.extract = function(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     get_extract_setup_pipeline(bufnr, opts)
@@ -617,7 +620,7 @@ M.extract = function(bufnr, opts)
 end
 
 ---@param bufnr integer
----@param opts c|Config
+---@param opts Config
 M.extract_block = function(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     Pipeline:from_task(refactor_setup(bufnr, opts))
@@ -629,7 +632,7 @@ M.extract_block = function(bufnr, opts)
 end
 
 ---@param bufnr integer
----@param opts c|Config
+---@param opts Config
 M.extract_block_to_file = function(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     Pipeline:from_task(refactor_setup(bufnr, opts))

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -462,8 +462,6 @@ local function extract_block_setup(refactor)
     refactor.region = region
     refactor.region_node = region_node
     refactor.scope = scope
-    refactor.whitespace.highlight_start = vim.fn.indent(region.start_row)
-    refactor.whitespace.highlight_end = vim.fn.indent(region.end_row)
 
     if refactor.scope == nil then
         return false, "Scope is nil"

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -521,9 +521,6 @@ local function extract_setup(refactor)
     local func_call = get_func_call(refactor, extract_params)
 
     local region_above_scope = get_non_comment_region_above_node(refactor)
-    if is_class then
-        region_above_scope = get_non_comment_region_above_node(refactor)
-    end
 
     local extract_function
     if is_class then

--- a/lua/refactoring/tasks/refactor_setup.lua
+++ b/lua/refactoring/tasks/refactor_setup.lua
@@ -7,7 +7,7 @@ local Point = require("refactoring.point")
 -- monstrosity
 
 ---@param input_bufnr number
----@param config c|Config
+---@param config Config
 ---@return fun(): true, Refactor
 local function refactor_setup(input_bufnr, config)
     input_bufnr = input_bufnr or vim.api.nvim_get_current_buf()
@@ -24,7 +24,7 @@ local function refactor_setup(input_bufnr, config)
 
         local ts = TreeSitter.get_treesitter()
 
-        local filetype = vim.bo[bufnr].filetype
+        local filetype = vim.bo[bufnr].filetype --[[@as ft]]
         local root = ts:get_root()
         local win = vim.api.nvim_get_current_win()
         local cursor = Point:from_cursor()
@@ -36,6 +36,7 @@ local function refactor_setup(input_bufnr, config)
         ---@field cursor_col_adjustment integer|nil
         ---@field text_edits LspTextEdit[] | {bufnr: integer|nil}[] | nil
         ---@field code code_generation
+        ---@field return_value string used by debug.get_path
         local refactor = {
             ---@type {cursor: integer, highlight_start: integer|nil, highlight_end: integer|nil, func_call: integer|nil}
             whitespace = {

--- a/lua/refactoring/tasks/refactor_setup.lua
+++ b/lua/refactoring/tasks/refactor_setup.lua
@@ -38,7 +38,7 @@ local function refactor_setup(input_bufnr, config)
         ---@field code code_generation
         ---@field return_value string used by debug.get_path
         local refactor = {
-            ---@type {cursor: integer, highlight_start: integer|nil, highlight_end: integer|nil, func_call: integer|nil}
+            ---@type {cursor: integer, func_call: integer|nil}
             whitespace = {
                 cursor = vim.fn.indent(cursor.row),
             },

--- a/lua/refactoring/tasks/selection_setup.lua
+++ b/lua/refactoring/tasks/selection_setup.lua
@@ -2,7 +2,9 @@ local Region = require("refactoring.region")
 
 ---@param refactor Refactor
 local function selection_setup(refactor)
-    local region = Region:from_current_selection()
+    local region = Region:from_current_selection({
+        include_end_of_line = refactor.ts.include_end_of_line,
+    })
     local region_node = region:to_ts_node(refactor.ts:get_root())
     local scope = refactor.ts:get_scope(region_node)
 

--- a/lua/refactoring/tasks/selection_setup.lua
+++ b/lua/refactoring/tasks/selection_setup.lua
@@ -11,8 +11,6 @@ local function selection_setup(refactor)
     refactor.region = region
     refactor.region_node = region_node
     refactor.scope = scope
-    refactor.whitespace.highlight_start = vim.fn.indent(region.start_row)
-    refactor.whitespace.highlight_end = vim.fn.indent(region.end_row)
 
     if refactor.scope == nil then
         return false, "Scope is nil"

--- a/lua/refactoring/tests/debug/cleanup/c/cleanup.start.c
+++ b/lua/refactoring/tests/debug/cleanup/c/cleanup.start.c
@@ -1,7 +1,8 @@
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {
-  printf("main(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+  printf("main 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF_END__
   printf("poggers");
   return 0;
 }

--- a/lua/refactoring/tests/debug/cleanup/cpp/cleanup.start.cpp
+++ b/lua/refactoring/tests/debug/cleanup/cpp/cleanup.start.cpp
@@ -1,7 +1,8 @@
 #include <iostream>
 
 int main(int argc, char *argv[]) {
-  printf("main(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+  printf("main 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF_END__
   std::cout << "poggers" << std::endl;
   return 0;
 }

--- a/lua/refactoring/tests/debug/cleanup/go/cleanup.start.go
+++ b/lua/refactoring/tests/debug/cleanup/go/cleanup.start.go
@@ -3,8 +3,10 @@ package main
 import "fmt"
 
 func main() {
-    fmt.Println("main") // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    fmt.Println("main 1") // __AUTO_GENERATED_PRINTF_END__
     var i int = 3
-    fmt.Println(fmt.Sprintf("main i: %v", i)) // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    fmt.Println(fmt.Sprintf("main i: %v", i)) // __AUTO_GENERATED_PRINT_VAR_END__
     fmt.Println("poggers", i)
 }

--- a/lua/refactoring/tests/debug/cleanup/java/cleanup.start.java
+++ b/lua/refactoring/tests/debug/cleanup/java/cleanup.start.java
@@ -3,7 +3,8 @@ class Extract {
     public static void simpleFunction(int a) {
         int test = 1, test_other = 11;
         for (int x = 0; x < test_other + test; x++) {
-            System.out.println("Extract#simpleFunction#for");// __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+            System.out.println("Extract#simpleFunction#for 1"); // __AUTO_GENERATED_PRINTF_END__
             System.out.println(x + " " + a);
         }
     }

--- a/lua/refactoring/tests/debug/cleanup/js/cleanup.start.js
+++ b/lua/refactoring/tests/debug/cleanup/js/cleanup.start.js
@@ -1,4 +1,5 @@
 function main() {
-    console.log("main"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    console.log("main 1"); // __AUTO_GENERATED_PRINTF_END__
     console.log("poggers");
 }

--- a/lua/refactoring/tests/debug/cleanup/lua/cleanup.start.lua
+++ b/lua/refactoring/tests/debug/cleanup/lua/cleanup.start.lua
@@ -1,8 +1,10 @@
 -- stylua: ignore start
 
 local function main()
-    print("main") -- __AUTO_GENERATED_PRINTF__
+-- __AUTO_GENERATED_PRINTF_START__
+    print("main 1") -- __AUTO_GENERATED_PRINTF_END__
     local i = 0
-    print("main i:", vim.inspect(i)) -- __AUTO_GENERATED_PRINT_VAR__
+-- __AUTO_GENERATED_PRINT_VAR_START__
+    print("main i:", vim.inspect(i)) -- __AUTO_GENERATED_PRINT_VAR_END__
     print("poggers")
 end

--- a/lua/refactoring/tests/debug/cleanup/py/cleanup.expected.py
+++ b/lua/refactoring/tests/debug/cleanup/py/cleanup.expected.py
@@ -1,4 +1,3 @@
-
 def main():
     print('poggers')
     i = 3

--- a/lua/refactoring/tests/debug/cleanup/py/cleanup.start.py
+++ b/lua/refactoring/tests/debug/cleanup/py/cleanup.start.py
@@ -1,6 +1,9 @@
-print(f"test")  # __AUTO_GENERATED_PRINTF__
+# __AUTO_GENERATED_PRINTF_START__
+print(f"main 1") # __AUTO_GENERATED_PRINTF_END__
 def main():
-    print(f"main")  # __AUTO_GENERATED_PRINTF__
+# __AUTO_GENERATED_PRINTF_START__
+    print(f"main 2") # __AUTO_GENERATED_PRINTF_END__
     print('poggers')
     i = 3
-    print(f" i: {str(i)}")  # __AUTO_GENERATED_PRINT_VAR__
+# __AUTO_GENERATED_PRINT_VAR_START__
+    print(f"main i: {str(i)}") # __AUTO_GENERATED_PRINT_VAR_END__

--- a/lua/refactoring/tests/debug/cleanup/rb/cleanup.expected.rb
+++ b/lua/refactoring/tests/debug/cleanup/rb/cleanup.expected.rb
@@ -1,4 +1,3 @@
-
 def main
   puts('ruby is awesome')
   i = 3

--- a/lua/refactoring/tests/debug/cleanup/rb/cleanup.expected.rb
+++ b/lua/refactoring/tests/debug/cleanup/rb/cleanup.expected.rb
@@ -1,4 +1,4 @@
 def main
-  puts('ruby is awesome')
+  puts("ruby is awesome")
   i = 3
 end

--- a/lua/refactoring/tests/debug/cleanup/rb/cleanup.start.rb
+++ b/lua/refactoring/tests/debug/cleanup/rb/cleanup.start.rb
@@ -1,7 +1,10 @@
-puts('test')  # __AUTO_GENERATED_PRINTF__
+# __AUTO_GENERATED_PRINTF_START__
+puts "test"  # __AUTO_GENERATED_PRINTF_END__
 def main
-  puts('main') # __AUTO_GENERATED_PRINTF__
-  puts('ruby is awesome')
+# __AUTO_GENERATED_PRINTF_START__
+  puts "main 1" # __AUTO_GENERATED_PRINTF_END__
+  puts("ruby is awesome")
   i = 3
-  puts(' i: {str(i)}')  # __AUTO_GENERATED_PRINT_VAR__
+# __AUTO_GENERATED_PRINT_VAR_START__
+  puts "main i: #{i}" # __AUTO_GENERATED_PRINT_VAR_END__
 end

--- a/lua/refactoring/tests/debug/cleanup/ts/cleanup.expected.ts
+++ b/lua/refactoring/tests/debug/cleanup/ts/cleanup.expected.ts
@@ -1,3 +1,4 @@
 function main() {
+  const thisIsAReallyLongVariableNameInOrderToHaveAMultiLinePrintVar = "";
   console.log("poggers");
 }

--- a/lua/refactoring/tests/debug/cleanup/ts/cleanup.start.ts
+++ b/lua/refactoring/tests/debug/cleanup/ts/cleanup.start.ts
@@ -1,4 +1,11 @@
 function main() {
-  console.log("main"); // __AUTO_GENERATED_PRINTF__
+  // __AUTO_GENERATED_PRINTF_START__
+  console.log("main 1"); // __AUTO_GENERATED_PRINTF_END__
+  const thisIsAReallyLongVariableNameInOrderToHaveAMultiLinePrintVar = "";
+  // __AUTO_GENERATED_PRINT_VAR_START__
+  console.log(
+    "main thisIsAReallyLongVariableNameInOrderToHaveAMultiLinePrintVar: %s",
+    thisIsAReallyLongVariableNameInOrderToHaveAMultiLinePrintVar
+  ); // __AUTO_GENERATED_PRINT_VAR_END__
   console.log("poggers");
 }

--- a/lua/refactoring/tests/debug/print_var/c/global-scope/print_var.expected.c
+++ b/lua/refactoring/tests/debug/print_var/c/global-scope/print_var.expected.c
@@ -1,2 +1,3 @@
 int i = 3;
-printf(" i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+printf(" i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR_END__

--- a/lua/refactoring/tests/debug/print_var/c/mutiple-statements/print_var.expected.c
+++ b/lua/refactoring/tests/debug/print_var/c/mutiple-statements/print_var.expected.c
@@ -1,4 +1,5 @@
 void simple_function() {
     int i = 3;
-    printf("custom print_var simple_function i: %d", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf("custom print_var simple_function i: %d", i); // __AUTO_GENERATED_PRINT_VAR_END__
 }

--- a/lua/refactoring/tests/debug/print_var/c/simple-function-nor-mode/print_var.expected.c
+++ b/lua/refactoring/tests/debug/print_var/c/simple-function-nor-mode/print_var.expected.c
@@ -1,4 +1,5 @@
 void simple_function() {
     int i = 3;
-    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR_END__
 }

--- a/lua/refactoring/tests/debug/print_var/c/simple-function/print_var.expected.c
+++ b/lua/refactoring/tests/debug/print_var/c/simple-function/print_var.expected.c
@@ -1,4 +1,5 @@
 void simple_function() {
     int i = 3;
-    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR_END__
 }

--- a/lua/refactoring/tests/debug/print_var/cpp/class-function/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/class-function/print_var.expected.cpp
@@ -1,6 +1,7 @@
 class Poggers {
     void simple_function() {
         int i = 3;
-        printf("Poggers#simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+        printf("Poggers#simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR_END__
     }
 }

--- a/lua/refactoring/tests/debug/print_var/cpp/global-scope/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/global-scope/print_var.expected.cpp
@@ -1,2 +1,3 @@
 int i = 3;
-printf(" i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+printf(" i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR_END__

--- a/lua/refactoring/tests/debug/print_var/cpp/mutiple-statements/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/mutiple-statements/print_var.expected.cpp
@@ -1,4 +1,5 @@
 void simple_function() {
     int i = 3;
-    printf("custom print_var simple_function i: %d", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf("custom print_var simple_function i: %d", i); // __AUTO_GENERATED_PRINT_VAR_END__
 }

--- a/lua/refactoring/tests/debug/print_var/cpp/simple-function-nor-mode/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/simple-function-nor-mode/print_var.expected.cpp
@@ -1,4 +1,5 @@
 void simple_function() {
     int i = 3;
-    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR_END__
 }

--- a/lua/refactoring/tests/debug/print_var/cpp/simple-function/print_var.expected.cpp
+++ b/lua/refactoring/tests/debug/print_var/cpp/simple-function/print_var.expected.cpp
@@ -1,4 +1,5 @@
 void simple_function() {
     int i = 3;
-    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf("simple_function i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR_END__
 }

--- a/lua/refactoring/tests/debug/print_var/go/multiple-statements/print_var.expected.go
+++ b/lua/refactoring/tests/debug/print_var/go/multiple-statements/print_var.expected.go
@@ -5,7 +5,8 @@ import "fmt"
 func simple_function(a int) {
     var test int = 1
     test_other := 1
-    fmt.Println(fmt.Sprintf("custom print var simple_function test_other:: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    fmt.Println(fmt.Sprintf("custom print var simple_function test_other:: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR_END__
     for idx := test - 1; idx < test_other; idx++ {
         fmt.Println(idx, a)
     }

--- a/lua/refactoring/tests/debug/print_var/go/simple-function-nor-mode/print_var.expected.go
+++ b/lua/refactoring/tests/debug/print_var/go/simple-function-nor-mode/print_var.expected.go
@@ -5,7 +5,8 @@ import "fmt"
 func simple_function(a int) {
     var test int = 1
     test_other := 1
-    fmt.Println(fmt.Sprintf("simple_function test_other: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    fmt.Println(fmt.Sprintf("simple_function test_other: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR_END__
     for idx := test - 1; idx < test_other; idx++ {
         fmt.Println(idx, a)
     }

--- a/lua/refactoring/tests/debug/print_var/go/simple-function/print_var.expected.go
+++ b/lua/refactoring/tests/debug/print_var/go/simple-function/print_var.expected.go
@@ -5,7 +5,8 @@ import "fmt"
 func simple_function(a int) {
     var test int = 1
     test_other := 1
-    fmt.Println(fmt.Sprintf("simple_function test_other: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    fmt.Println(fmt.Sprintf("simple_function test_other: %v", test_other)) // __AUTO_GENERATED_PRINT_VAR_END__
     for idx := test - 1; idx < test_other; idx++ {
         fmt.Println(idx, a)
     }

--- a/lua/refactoring/tests/debug/print_var/java/class-function/print_var.expected.java
+++ b/lua/refactoring/tests/debug/print_var/java/class-function/print_var.expected.java
@@ -2,7 +2,8 @@ class Extract {
 
   public static void simpleFunction(int a) {
     int i = 3;
-    System.out.printf("Extract#simpleFunction i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    System.out.printf("Extract#simpleFunction i: %s \n", i); // __AUTO_GENERATED_PRINT_VAR_END__
     System.out.println(i);
   }
 }

--- a/lua/refactoring/tests/debug/print_var/java/multiple-statements/print_var.expected.java
+++ b/lua/refactoring/tests/debug/print_var/java/multiple-statements/print_var.expected.java
@@ -2,7 +2,8 @@ class Extract {
 
   public static void simpleFunction(int a) {
     int i = 3;
-    System.out.printf("custom print_var Extract#simpleFunction i:: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    System.out.printf("custom print_var Extract#simpleFunction i:: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__
     System.out.println(i);
   }
 }

--- a/lua/refactoring/tests/debug/print_var/js/class-function/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/class-function/print_var.expected.js
@@ -1,7 +1,8 @@
 class Poggers {
     simple_function() {
         const i = 3;
-        console.log("Poggers#simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+        console.log("Poggers#simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__
         console.log(i);
     }
 }

--- a/lua/refactoring/tests/debug/print_var/js/global-scope/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/global-scope/print_var.expected.js
@@ -1,2 +1,3 @@
 const i = 3;
-console.log(" i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+console.log(" i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__

--- a/lua/refactoring/tests/debug/print_var/js/multiple-statements/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/multiple-statements/print_var.expected.js
@@ -1,5 +1,6 @@
 function simple_function() {
     const i = 3;
-    console.log("custom print var simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    console.log("custom print var simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/print_var/js/simple-function-nor-mode/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/simple-function-nor-mode/print_var.expected.js
@@ -1,5 +1,6 @@
 function simple_function() {
     const i = 3;
-    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/print_var/js/simple-function/print_var.expected.js
+++ b/lua/refactoring/tests/debug/print_var/js/simple-function/print_var.expected.js
@@ -1,5 +1,6 @@
 function simple_function() {
     const i = 3;
-    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/print_var/lua/multiple-statements/print_var.expected.lua
+++ b/lua/refactoring/tests/debug/print_var/lua/multiple-statements/print_var.expected.lua
@@ -1,7 +1,8 @@
 function simple_function(a)
     local test = 1
     local test_other = 11
-    print("custom print_var simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR__
+-- __AUTO_GENERATED_PRINT_VAR_START__
+    print("custom print_var simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR_END__
     for idx = test - 1, test_other do
         print(idx, a)
     end

--- a/lua/refactoring/tests/debug/print_var/lua/simple-function-nor-mode/print_var.expected.lua
+++ b/lua/refactoring/tests/debug/print_var/lua/simple-function-nor-mode/print_var.expected.lua
@@ -1,7 +1,8 @@
 function simple_function(a)
     local test = 1
     local test_other = 11
-    print("simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR__
+-- __AUTO_GENERATED_PRINT_VAR_START__
+    print("simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR_END__
     for idx = test - 1, test_other do
         print(idx, a)
     end

--- a/lua/refactoring/tests/debug/print_var/lua/simple-function/print_var.expected.lua
+++ b/lua/refactoring/tests/debug/print_var/lua/simple-function/print_var.expected.lua
@@ -1,7 +1,8 @@
 function simple_function(a)
     local test = 1
     local test_other = 11
-    print("simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR__
+-- __AUTO_GENERATED_PRINT_VAR_START__
+    print("simple_function test_other:", vim.inspect(test_other)) -- __AUTO_GENERATED_PRINT_VAR_END__
     for idx = test - 1, test_other do
         print(idx, a)
     end

--- a/lua/refactoring/tests/debug/print_var/php/multiple-statements/print_var.expected.php
+++ b/lua/refactoring/tests/debug/print_var/php/multiple-statements/print_var.expected.php
@@ -1,6 +1,7 @@
 <?php
 function testFunction() {
     $testVariable = 'Hello Kiwi';
-    printf('custom print_var testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf('custom print_var testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR_END__
 }
 ?>

--- a/lua/refactoring/tests/debug/print_var/php/simple-function-nor-mode/print_var.expected.php
+++ b/lua/refactoring/tests/debug/print_var/php/simple-function-nor-mode/print_var.expected.php
@@ -1,6 +1,7 @@
 <?php
 function testFunction() {
     $testVariable = 'Hello Kiwi';
-    printf('testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf('testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR_END__
 }
 ?>

--- a/lua/refactoring/tests/debug/print_var/php/simple-function/print_var.expected.php
+++ b/lua/refactoring/tests/debug/print_var/php/simple-function/print_var.expected.php
@@ -1,6 +1,7 @@
 <?php
 function testFunction() {
     $testVariable = 'Hello Kiwi';
-    printf('testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    printf('testFunction $testVariable: %s'."\n", $testVariable); // __AUTO_GENERATED_PRINT_VAR_END__
 }
 ?>

--- a/lua/refactoring/tests/debug/print_var/py/multiple-statements/print_var.expected.py
+++ b/lua/refactoring/tests/debug/print_var/py/multiple-statements/print_var.expected.py
@@ -2,7 +2,8 @@ class Poggers:
 
     def simple_function(self, a):
         test = 1
-        print(f"custom print_var Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR__
+# __AUTO_GENERATED_PRINT_VAR_START__
+        print(f"custom print_var Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR_END__
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/debug/print_var/py/simple-function-nor-mode/print_var.expected.py
+++ b/lua/refactoring/tests/debug/print_var/py/simple-function-nor-mode/print_var.expected.py
@@ -2,7 +2,8 @@ class Poggers:
 
     def simple_function(self, a):
         test = 1
-        print(f"Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR__
+# __AUTO_GENERATED_PRINT_VAR_START__
+        print(f"Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR_END__
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/debug/print_var/py/simple-function/print_var.expected.py
+++ b/lua/refactoring/tests/debug/print_var/py/simple-function/print_var.expected.py
@@ -2,7 +2,8 @@ class Poggers:
 
     def simple_function(self, a):
         test = 1
-        print(f"Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR__
+# __AUTO_GENERATED_PRINT_VAR_START__
+        print(f"Poggers#simple_function test: {str(test)}") # __AUTO_GENERATED_PRINT_VAR_END__
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/debug/print_var/rb/multiple-statements/print_var.expected.rb
+++ b/lua/refactoring/tests/debug/print_var/rb/multiple-statements/print_var.expected.rb
@@ -2,7 +2,8 @@ class SimpleClass
   def simple_function(a)
     test = 1
     test_other = 11
-    puts "custom print_var SimpleClass#simple_function test_other: #{test_other}" # __AUTO_GENERATED_PRINT_VAR__
+# __AUTO_GENERATED_PRINT_VAR_START__
+    puts "custom print_var SimpleClass#simple_function test_other: #{test_other}" # __AUTO_GENERATED_PRINT_VAR_END__
     for x in test..test_other do
       puts x, a
     end

--- a/lua/refactoring/tests/debug/print_var/rb/simple-function-nor-mode/print_var.expected.rb
+++ b/lua/refactoring/tests/debug/print_var/rb/simple-function-nor-mode/print_var.expected.rb
@@ -2,7 +2,8 @@ class SimpleClass
   def simple_function(a)
     test = 1
     test_other = 11
-    puts "SimpleClass#simple_function test_other: #{test_other}" # __AUTO_GENERATED_PRINT_VAR__
+# __AUTO_GENERATED_PRINT_VAR_START__
+    puts "SimpleClass#simple_function test_other: #{test_other}" # __AUTO_GENERATED_PRINT_VAR_END__
     for x in test..test_other do
       puts x, a
     end

--- a/lua/refactoring/tests/debug/print_var/rb/simple-function/print_var.expected.rb
+++ b/lua/refactoring/tests/debug/print_var/rb/simple-function/print_var.expected.rb
@@ -2,7 +2,8 @@ class SimpleClass
   def simple_function(a)
     test = 1
     test_other = 11
-    puts "SimpleClass#simple_function test_other: #{test_other}" # __AUTO_GENERATED_PRINT_VAR__
+# __AUTO_GENERATED_PRINT_VAR_START__
+    puts "SimpleClass#simple_function test_other: #{test_other}" # __AUTO_GENERATED_PRINT_VAR_END__
     for x in test..test_other do
       puts x, a
     end

--- a/lua/refactoring/tests/debug/print_var/ts/class-function/print_var.expected.ts
+++ b/lua/refactoring/tests/debug/print_var/ts/class-function/print_var.expected.ts
@@ -1,7 +1,8 @@
 class Poggers {
   simple_function() {
     const i = 3;
-    console.log("Poggers#simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    console.log("Poggers#simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__
     console.log(i);
   }
 }

--- a/lua/refactoring/tests/debug/print_var/ts/global-scope/print_var.expected.ts
+++ b/lua/refactoring/tests/debug/print_var/ts/global-scope/print_var.expected.ts
@@ -1,2 +1,3 @@
 const i = 3;
-console.log(" i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+console.log(" i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__

--- a/lua/refactoring/tests/debug/print_var/ts/multiple-statements/print_var.expected.ts
+++ b/lua/refactoring/tests/debug/print_var/ts/multiple-statements/print_var.expected.ts
@@ -1,5 +1,6 @@
 function simple_function() {
     const i = 3;
-    console.log("custom print var simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    console.log("custom print var simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/print_var/ts/simple-function/print_var.expected.ts
+++ b/lua/refactoring/tests/debug/print_var/ts/simple-function/print_var.expected.ts
@@ -1,5 +1,6 @@
 function simple_function() {
     const i = 3;
-    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR__
+// __AUTO_GENERATED_PRINT_VAR_START__
+    console.log("simple_function i: %s", i); // __AUTO_GENERATED_PRINT_VAR_END__
     console.log(i);
 }

--- a/lua/refactoring/tests/debug/printf/c/multiple-statements/printf.expected.c
+++ b/lua/refactoring/tests/debug/printf/c/multiple-statements/printf.expected.c
@@ -1,5 +1,6 @@
 int main (int argc, char *argv[])
 {
-    printf("debug path main 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    printf("debug path main 1"); // __AUTO_GENERATED_PRINTF_END__
     return 0;
 }

--- a/lua/refactoring/tests/debug/printf/c/simple-function/printf.expected.c
+++ b/lua/refactoring/tests/debug/printf/c/simple-function/printf.expected.c
@@ -1,5 +1,6 @@
 int main() {
     return 0;
-    printf("main 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    printf("main 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF_END__
 }
 

--- a/lua/refactoring/tests/debug/printf/cpp/class-function/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/class-function/printf.expected.cpp
@@ -8,5 +8,6 @@ class Test {
 
 void Test::foo() {
 
-printf("Test::foo 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+printf("Test::foo 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF_END__
 }

--- a/lua/refactoring/tests/debug/printf/cpp/destructor/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/destructor/printf.expected.cpp
@@ -4,7 +4,8 @@ class Test {
     public:
         ~Test() {
 
-        printf("Test#~Test 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+        printf("Test#~Test 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF_END__
         }
 };
 

--- a/lua/refactoring/tests/debug/printf/cpp/inline-class-function/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/inline-class-function/printf.expected.cpp
@@ -5,7 +5,8 @@ class Test {
         ~Test() { }
         void foo() {
 
-        printf("Test#foo 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+        printf("Test#foo 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF_END__
         }
 };
 

--- a/lua/refactoring/tests/debug/printf/cpp/multiple-statements/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/multiple-statements/printf.expected.cpp
@@ -1,5 +1,6 @@
 int main (int argc, char *argv[])
 {
-    printf("debug path main 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    printf("debug path main 1"); // __AUTO_GENERATED_PRINTF_END__
     return 0;
 }

--- a/lua/refactoring/tests/debug/printf/cpp/simple-function/printf.expected.cpp
+++ b/lua/refactoring/tests/debug/printf/cpp/simple-function/printf.expected.cpp
@@ -1,5 +1,6 @@
 int main() {
     return 0;
-    printf("main 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    printf("main 1(%d): \n", __LINE__); // __AUTO_GENERATED_PRINTF_END__
 }
 

--- a/lua/refactoring/tests/debug/printf/go/multiple-statements/printf.expected.go
+++ b/lua/refactoring/tests/debug/printf/go/multiple-statements/printf.expected.go
@@ -4,5 +4,6 @@ import "fmt"
 
 func main() {
     fmt.Println("test")
-    fmt.Println("debug path main 1") // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    fmt.Println("debug path main 1") // __AUTO_GENERATED_PRINTF_END__
 }

--- a/lua/refactoring/tests/debug/printf/go/simple-function/printf.expected.go
+++ b/lua/refactoring/tests/debug/printf/go/simple-function/printf.expected.go
@@ -7,6 +7,7 @@ func simple_function(a int) {
     test_other := 1
     for idx := test - 1; idx < test_other; idx++ {
         fmt.Println(idx, a)
-        fmt.Println("simple_function 1") // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+        fmt.Println("simple_function 1") // __AUTO_GENERATED_PRINTF_END__
     }
 }

--- a/lua/refactoring/tests/debug/printf/java/class-function/printf.expected.java
+++ b/lua/refactoring/tests/debug/printf/java/class-function/printf.expected.java
@@ -3,7 +3,8 @@ class Extract {
     public static void simpleFunction(int a) {
         int test = 1, test_other = 11;
         for (int x = 0; x < test_other + test; x++) {
-            System.out.println("Extract#simpleFunction#for 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+            System.out.println("Extract#simpleFunction#for 1"); // __AUTO_GENERATED_PRINTF_END__
             System.out.println(x + " " + a);
         }
     }

--- a/lua/refactoring/tests/debug/printf/java/multiple-statements/printf.expected.java
+++ b/lua/refactoring/tests/debug/printf/java/multiple-statements/printf.expected.java
@@ -1,6 +1,7 @@
 class Printf {
     public static void main(String[] args) {
         System.out.println("test");
-        System.out.println("debug path Printf#main 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+        System.out.println("debug path Printf#main 1"); // __AUTO_GENERATED_PRINTF_END__
     }
 }

--- a/lua/refactoring/tests/debug/printf/js/multiple-statements/printf.expected.js
+++ b/lua/refactoring/tests/debug/printf/js/multiple-statements/printf.expected.js
@@ -1,4 +1,5 @@
 function main() {
-    console.log("debug path main 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    console.log("debug path main 1"); // __AUTO_GENERATED_PRINTF_END__
     return 0;
 }

--- a/lua/refactoring/tests/debug/printf/js/simple-function/printf.expected.js
+++ b/lua/refactoring/tests/debug/printf/js/simple-function/printf.expected.js
@@ -2,7 +2,8 @@ class foo {
 
     test() {
         "that seems wrong"
-        console.log("foo#test 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+        console.log("foo#test 1"); // __AUTO_GENERATED_PRINTF_END__
         return 5
     }
 }

--- a/lua/refactoring/tests/debug/printf/lua/multiple-statements/printf.expected.lua
+++ b/lua/refactoring/tests/debug/printf/lua/multiple-statements/printf.expected.lua
@@ -1,5 +1,6 @@
 -- stylua: ignore start
 local hello = function()
     print("test")
-    print("debug path function 1"); -- __AUTO_GENERATED_PRINTF__
+-- __AUTO_GENERATED_PRINTF_START__
+    print("debug path function 1"); -- __AUTO_GENERATED_PRINTF_END__
 end

--- a/lua/refactoring/tests/debug/printf/lua/simple/printf.expected.lua
+++ b/lua/refactoring/tests/debug/printf/lua/simple/printf.expected.lua
@@ -1,4 +1,6 @@
+-- stylua: ignore start
 local function poggers()
+-- __AUTO_GENERATED_PRINTF_START__
+    print("poggers 1") -- __AUTO_GENERATED_PRINTF_END__
     print("this function is quite simple indeed")
-    print("poggers 1") -- __AUTO_GENERATED_PRINTF__
 end

--- a/lua/refactoring/tests/debug/printf/lua/simple/printf.start.lua
+++ b/lua/refactoring/tests/debug/printf/lua/simple/printf.start.lua
@@ -1,3 +1,4 @@
+-- stylua: ignore start
 local function poggers()
     print("this function is quite simple indeed")
 end

--- a/lua/refactoring/tests/debug/printf/php/multiple-statements/printf.expected.php
+++ b/lua/refactoring/tests/debug/printf/php/multiple-statements/printf.expected.php
@@ -1,5 +1,6 @@
 <?php
 function testFunction() {
-printf("debug path testFunction 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+printf("debug path testFunction 1"); // __AUTO_GENERATED_PRINTF_END__
 }
 ?>

--- a/lua/refactoring/tests/debug/printf/php/simple-function/printf.expected.php
+++ b/lua/refactoring/tests/debug/printf/php/simple-function/printf.expected.php
@@ -1,5 +1,6 @@
 <?php
 function testFunction() {
-printf("testFunction 1\n"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+printf("testFunction 1\n"); // __AUTO_GENERATED_PRINTF_END__
 }
 ?>

--- a/lua/refactoring/tests/debug/printf/py/multiple-statements/printf.expected.py
+++ b/lua/refactoring/tests/debug/printf/py/multiple-statements/printf.expected.py
@@ -1,3 +1,4 @@
 def main():
-    print("debug path main 1") # __AUTO_GENERATED_PRINTF__
+# __AUTO_GENERATED_PRINTF_START__
+    print("debug path main 1") # __AUTO_GENERATED_PRINTF_END__
     pass

--- a/lua/refactoring/tests/debug/printf/py/simple/printf.expected.py
+++ b/lua/refactoring/tests/debug/printf/py/simple/printf.expected.py
@@ -2,7 +2,8 @@ class Poggers:
 
     def simple_function(self, a):
         test = 1
-        print(f"Poggers#simple_function 1") # __AUTO_GENERATED_PRINTF__
+# __AUTO_GENERATED_PRINTF_START__
+        print(f"Poggers#simple_function 1") # __AUTO_GENERATED_PRINTF_END__
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/debug/printf/rb/complex-function/printf.expected.rb
+++ b/lua/refactoring/tests/debug/printf/rb/complex-function/printf.expected.rb
@@ -1,7 +1,8 @@
 module SimpleModule
     class SimpleClass
         def simple_function(a)
-            puts "SimpleModule#SimpleClass#simple_function 1" # __AUTO_GENERATED_PRINTF__
+# __AUTO_GENERATED_PRINTF_START__
+            puts "SimpleModule#SimpleClass#simple_function 1" # __AUTO_GENERATED_PRINTF_END__
             test = 1
             test_other = 11
             for x in test..test_other do

--- a/lua/refactoring/tests/debug/printf/rb/multiple-statements/printf.expected.rb
+++ b/lua/refactoring/tests/debug/printf/rb/multiple-statements/printf.expected.rb
@@ -1,4 +1,5 @@
 def main
-    puts "debug path main 1" # __AUTO_GENERATED_PRINTF__
+# __AUTO_GENERATED_PRINTF_START__
+    puts "debug path main 1" # __AUTO_GENERATED_PRINTF_END__
     pass
 end

--- a/lua/refactoring/tests/debug/printf/rb/simple-function/printf.expected.rb
+++ b/lua/refactoring/tests/debug/printf/rb/simple-function/printf.expected.rb
@@ -1,7 +1,8 @@
 class SimpleClass
     def simple_function(a)
         test = 1
-        puts "SimpleClass#simple_function 1" # __AUTO_GENERATED_PRINTF__
+# __AUTO_GENERATED_PRINTF_START__
+        puts "SimpleClass#simple_function 1" # __AUTO_GENERATED_PRINTF_END__
         test_other = 11
         for x in test..test_other do
             puts x, a

--- a/lua/refactoring/tests/debug/printf/ts/multiple-statements/printf.expected.ts
+++ b/lua/refactoring/tests/debug/printf/ts/multiple-statements/printf.expected.ts
@@ -1,4 +1,5 @@
 function main() {
-    console.log("debug path main 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+    console.log("debug path main 1"); // __AUTO_GENERATED_PRINTF_END__
     return 0;
 }

--- a/lua/refactoring/tests/debug/printf/ts/simple-function/printf.expected.ts
+++ b/lua/refactoring/tests/debug/printf/ts/simple-function/printf.expected.ts
@@ -2,7 +2,8 @@ class foo {
 
     test() {
         "that seems wrong"
-        console.log("foo#test 1"); // __AUTO_GENERATED_PRINTF__
+// __AUTO_GENERATED_PRINTF_START__
+        console.log("foo#test 1"); // __AUTO_GENERATED_PRINTF_END__
         return 5
     }
 }

--- a/lua/refactoring/tests/refactor/119/php/custom_extract_var_statement/extract_var.commands
+++ b/lua/refactoring/tests/refactor/119/php/custom_extract_var_statement/extract_var.commands
@@ -1,1 +1,1 @@
-:execute "norm! 15jwv3E\<Esc>"
+:execute "norm! 15jwv3Eh\<Esc>"

--- a/lua/refactoring/tests/refactor/119/php/example/extract_var.commands
+++ b/lua/refactoring/tests/refactor/119/php/example/extract_var.commands
@@ -1,1 +1,1 @@
-:execute "norm! 15jwv3E\<Esc>"
+:execute "norm! 15jwv3Eh\<Esc>"

--- a/lua/refactoring/tests/refactor/119/tsx/simple-component/extract_var.commands
+++ b/lua/refactoring/tests/refactor/119/tsx/simple-component/extract_var.commands
@@ -1,2 +1,2 @@
 :4
-:execute "norm! _v$\<Esc>"
+:execute "norm! _v$h\<Esc>"

--- a/lua/refactoring/treesitter/langs/python.lua
+++ b/lua/refactoring/treesitter/langs/python.lua
@@ -98,6 +98,7 @@ function Python.new(bufnr, ft)
                 "(expression_statement (assignment left: ((attribute attribute: ((identifier) @capture)))))"
             ),
         },
+        include_end_of_line = true,
     }
     local ts = TreeSitter:new(config, bufnr)
 

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -29,6 +29,7 @@ local Region = require("refactoring.region")
 ---@field argument_type_index 1|2: 1-indexed location of type in function args (int foo= 1, foo int= 2)
 ---@field require_special_var_format boolean: flag to require special variable format for codegen
 ---@field should_check_parent_node fun(parent_type: string): boolean is checking the parent node necesary for context?
+---@field include_end_of_line boolean flag to indicate if end of line should be included in a region
 
 --- The following fields act similar to a cursor
 ---@class TreeSitter: TreeSitterLanguageConfig


### PR DESCRIPTION
Minor refactors, adds a bunch of types anotations, fixes the problem with always returning end_col - 2 on `Region:to_ts`.

A comment is inserted before `printf` and `print_var` to allow the deletion of multiline debug statements.