### PR TITLE
refactor!: remove dependency on nvim-treesitter and use the vim api instead

### DIFF
--- a/lua/refactoring/debug/print_var.lua
+++ b/lua/refactoring/debug/print_var.lua
@@ -4,7 +4,6 @@ local Region = require("refactoring.region")
 local refactor_setup = require("refactoring.tasks.refactor_setup")
 local post_refactor = require("refactoring.tasks.post_refactor")
 local lsp_utils = require("refactoring.lsp_utils")
-local parsers = require("nvim-treesitter.parsers")
 local debug_utils = require("refactoring.debug.debug_utils")
 local ensure_code_gen = require("refactoring.tasks.ensure_code_gen")
 local get_select_input = require("refactoring.get_select_input")
@@ -52,7 +51,7 @@ end
 local function get_variable(opts, point, refactor)
     if opts.normal then
         local bufnr = 0
-        local root_lang_tree = parsers.get_parser(bufnr)
+        local root_lang_tree = vim.treesitter.get_parser(bufnr)
         local row = point.row
         local col = point.col
         local lang_tree = root_lang_tree:language_for_range({

--- a/lua/refactoring/query.lua
+++ b/lua/refactoring/query.lua
@@ -1,5 +1,3 @@
-local parsers = require("nvim-treesitter.parsers")
-
 --- local myEnum = Enum {
 ---     'Foo',          -- Takes value 1
 ---     'Bar',          -- Takes value 2
@@ -26,7 +24,7 @@ Query.query_type = {
 ---@return TSNode
 function Query.get_root(bufnr, filetype)
     local lang = vim.treesitter.language.get_lang(filetype)
-    local parser = parsers.get_parser(bufnr or 0, lang)
+    local parser = vim.treesitter.get_parser(bufnr or 0, lang)
     if not parser then
         error(
             "No treesitter parser found. Install one using :TSInstall <language>"

--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -32,7 +32,7 @@ local function determine_declarator_node(refactor, bufnr)
     if declarator_node then
         return declarator_node, false
     else
-        local current_node = ts.get_node_at_cursor(0)
+        local current_node = ts.get_node_at_cursor()
         local definition = ts.find_definition(current_node, bufnr)
         declarator_node =
             refactor.ts.get_container(definition, refactor.ts.variable_scope)
@@ -112,7 +112,7 @@ local function inline_var_setup(refactor, bufnr)
     local node_to_inline, identifier_pos, definition
 
     if node_on_cursor then
-        node_to_inline = ts.get_node_at_cursor(0)
+        node_to_inline = ts.get_node_at_cursor()
         if
             refactor.ts.should_check_parent_node
             and refactor.ts.should_check_parent_node(node_to_inline:type())

--- a/lua/refactoring/tests/lsp_utils_spec.lua
+++ b/lua/refactoring/tests/lsp_utils_spec.lua
@@ -21,7 +21,7 @@ describe("lsp_utils", function()
         test_utils.vim_motion("fo")
         assert.are.same(vim.fn.expand("<cWORD>"), "foo")
 
-        local current_node = ts.get_node_at_cursor(0)
+        local current_node = ts.get_node_at_cursor()
         local definition = ts.find_definition(current_node, bufnr)
         local def_region = Region:from_node(definition)
         local references = ts.find_references(definition, nil, bufnr)

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -1,4 +1,3 @@
-local parsers = require("nvim-treesitter.parsers")
 local Point = require("refactoring.point")
 local utils = require("refactoring.utils")
 local Region = require("refactoring.region")
@@ -428,7 +427,7 @@ end
 ---@return TSNode
 function TreeSitter:get_root()
     local lang = vim.treesitter.language.get_lang(self.filetype)
-    local parser = parsers.get_parser(self.bufnr, lang)
+    local parser = vim.treesitter.get_parser(self.bufnr, lang)
     return parser:parse()[1]:root()
 end
 

--- a/lua/refactoring/ts.lua
+++ b/lua/refactoring/ts.lua
@@ -1,12 +1,10 @@
 local ts_locals = require("nvim-treesitter.locals")
-local ts_utils = require("nvim-treesitter.ts_utils")
 
 local M = {}
 
----@param win integer
----@return TSNode
-M.get_node_at_cursor = function(win)
-    return ts_utils.get_node_at_cursor(win)
+---@return TSNode|nil
+M.get_node_at_cursor = function()
+    return vim.treesitter.get_node()
 end
 
 ---@param node TSNode


### PR DESCRIPTION
The new main branch of nvim-ts removes a lot of the baggage that master has, and brings a lot of performance improvements, but it also removes a lot of utilities that projects like this used. Master is likely to be deprecated after 0.10, so I'm refactoring the necessary updates to prepare for that, and allow users to use main for nvim-ts