### PR TITLE
perf: do not eagerly require modules on init

### DIFF
--- a/lua/refactoring/command.lua
+++ b/lua/refactoring/command.lua
@@ -1,6 +1,3 @@
-local refactors = require("refactoring.refactor")
-local Config = require("refactoring.config")
-
 local M = {}
 
 --- @alias command_opts {name: string, args: string, fargs: string[], bang: boolean, line1: number, line2: number, range: number, count: number, reg: string, mods: string, smods: string[]}
@@ -18,6 +15,8 @@ local _needed_args = {
 --- @param opts command_opts
 --- @param ns integer
 local function command_preview(opts, ns)
+    local refactors = require("refactoring.refactor")
+
     local refactor = opts.fargs[1]
 
     refactor = refactors[refactor] and refactor
@@ -49,7 +48,7 @@ local function command_preview(opts, ns)
     for i = 2, needed_args + 1 do
         table.insert(args, opts.fargs[i])
     end
-    Config:get():automate_input(args)
+    require("refactoring.config"):get():automate_input(args)
 
     require("refactoring").refactor(refactor, { _preview_namespace = ns })
 
@@ -72,7 +71,7 @@ local function command(opts)
         table.insert(args, opts.fargs[i])
     end
 
-    Config:get():automate_input(args)
+    require("refactoring.config"):get():automate_input(args)
     require("refactoring").refactor(refactor)
 end
 
@@ -81,6 +80,8 @@ end
 ---@param _cursor_pos integer
 ---@return string[]
 local function command_complete(arg_lead, cmd_line, _cursor_pos)
+    local refactors = require("refactoring.refactor")
+
     local number_of_arguments = #vim.split(cmd_line, " ")
 
     if number_of_arguments > 2 then

--- a/lua/refactoring/init.lua
+++ b/lua/refactoring/init.lua
@@ -1,18 +1,14 @@
-local refactors = require("refactoring.refactor")
-local Config = require("refactoring.config")
-local get_select_input = require("refactoring.get_select_input")
-local async = require("plenary.async")
-
 local M = {}
 
 ---@param config ConfigOpts
 function M.setup(config)
-    Config.setup(config)
+    require("refactoring.config").setup(config)
 end
 
 ---@param name string|number
 ---@param opts ConfigOpts|nil
 function M.refactor(name, opts)
+    local refactors = require("refactoring.refactor")
     if opts == nil then
         opts = {}
     end
@@ -28,12 +24,14 @@ function M.refactor(name, opts)
         )
     end
 
+    local Config = require("refactoring.config")
     local config = Config.get():merge(opts)
     refactors[refactor](vim.api.nvim_get_current_buf(), config)
 end
 
 ---@return string[]
 function M.get_refactors()
+    local refactors = require("refactoring.refactor")
     return vim.tbl_keys(refactors.refactor_names)
 end
 
@@ -45,8 +43,8 @@ function M.select_refactor(opts)
         vim.cmd("norm! ")
     end
 
-    async.run(function()
-        local selected_refactor = get_select_input(
+    require("plenary.async").run(function()
+        local selected_refactor = require("refactoring.get_select_input")(
             M.get_refactors(),
             "Refactoring: select a refactor to apply:"
         )


### PR DESCRIPTION
Details: this affects lua/refactoring/init.lua (run when calling `setup`) and lua/refactoring/command.lua (run on startup)