### PR TITLE
feat(extract_func): make visibility keyword configurable for classes

### DIFF
--- a/lua/refactoring/code_generation/langs/php.lua
+++ b/lua/refactoring/code_generation/langs/php.lua
@@ -31,13 +31,14 @@ local function php_class_function(opts)
 
     return string.format(
         [[
-%spublic function %s (
+%s%s function %s (
 %s    %s
 %s) {
 %s
 %s}
 ]],
         opts.func_header,
+        opts.visibility,
         opts.name,
         opts.func_header,
         table.concat(opts.args, ", "),

--- a/lua/refactoring/config/init.lua
+++ b/lua/refactoring/config/init.lua
@@ -51,6 +51,11 @@ local default_prompt_func_return_type = {
     cxx = false,
 }
 
+local default_visibility = {
+    php = "public",
+    default = false,
+}
+
 local default_printf_statements = {}
 local default_print_var_statements = {}
 local default_extract_var_statements = {}
@@ -108,6 +113,7 @@ local default_extract_var_statements = {}
 ---@field printf_statements? table<ft, string[]>
 ---@field print_var_statements? table<ft, string[]>
 ---@field extract_var_statements? table<ft, string>
+---@field visibility? table<ft, string>
 ---@field below? boolean
 ---@field _end? boolean
 
@@ -135,6 +141,7 @@ function Config:new(...)
         printf_statements = vim.deepcopy(default_printf_statements),
         print_var_statements = vim.deepcopy(default_print_var_statements),
         extract_var_statements = vim.deepcopy(default_extract_var_statements),
+        visibility = vim.deepcopy(default_visibility),
     })
 
     for idx = 1, select("#", ...) do
@@ -166,6 +173,7 @@ function Config:reset()
     c.printf_statements = vim.deepcopy(default_printf_statements)
     c.print_var_statements = vim.deepcopy(default_print_var_statements)
     c.extract_var_statements = vim.deepcopy(default_extract_var_statements)
+    c.visibility = vim.deepcopy(default_visibility)
 end
 
 ---@param inputs string|string[]
@@ -284,6 +292,13 @@ end
 function Config:get_formatting_for(filetype)
     filetype = filetype or vim.bo[0].ft
     return self.config.formatting[filetype] or self.config.formatting["default"]
+end
+
+---@param filetype ft
+---@return string
+function Config:get_visibility_for(filetype)
+    filetype = filetype or vim.bo[0].ft
+    return self.config.visibility[filetype] or self.config.visibility["default"]
 end
 
 local config = Config:new()

--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -196,6 +196,7 @@ local function get_func_params(extract_params, refactor)
         scope_type = extract_params.scope_type,
         ---@type string
         region_type = refactor.region:to_ts_node(refactor.ts:get_root()):type(),
+        visibility = refactor.config:get_visibility_for(refactor.filetype),
     }
 
     if refactor.ts.require_param_types then
@@ -227,6 +228,8 @@ local function get_function_code(refactor, extract_params)
 
     if extract_params.is_class then
         func_params.className = refactor.ts:get_class_name(refactor.scope)
+        func_params.visibility =
+            refactor.config:get_visibility_for(refactor.filetype)
         if extract_params.has_return_vals then
             function_code = refactor.code.class_function_return(func_params)
         else


### PR DESCRIPTION
When the extract function is inside a class pass the visibility keyword as an option. Currently it is only "wired" to work with php classes.

I don't know if this is the best approach  or even if this feature is wanted, but as a user i thought it would be nice to have.

I would appreciate some feedback if it needs changes or additions to be complete.