### PR TITLE
feat(ts-locals)!: switch to upstream captures

### DIFF
--- a/lua/refactoring/query.lua
+++ b/lua/refactoring/query.lua
@@ -14,9 +14,9 @@ local Query = {}
 Query.__index = Query
 
 Query.query_type = {
-    FunctionArgument = "definition.function_argument",
-    LocalVarName = "definition.local_name",
-    Reference = "reference",
+    FunctionArgument = "local.definition.function_argument",
+    LocalVarName = "local.definition.local_name",
+    Reference = "local.reference",
 }
 
 ---@param bufnr integer

--- a/lua/refactoring/treesitter/treesitter.lua
+++ b/lua/refactoring/treesitter/treesitter.lua
@@ -1,6 +1,7 @@
 local Point = require("refactoring.point")
 local utils = require("refactoring.utils")
 local Region = require("refactoring.region")
+local ts_locals = require("refactoring.ts-locals")
 
 ---@class TreeSitterLanguageConfig
 ---@field bufnr integer bufnr to which this belongs
@@ -267,7 +268,7 @@ function TreeSitter:get_references(scope)
     local out = {}
     for id, node, _ in query:iter_captures(scope, self.bufnr, 0, -1) do
         local n_capture = query.captures[id]
-        if n_capture == "reference" then
+        if n_capture == ts_locals.local_reference then
             table.insert(out, node)
         end
     end

--- a/lua/refactoring/ts-locals.lua
+++ b/lua/refactoring/ts-locals.lua
@@ -7,12 +7,12 @@
 local api = vim.api
 local ts = vim.treesitter
 
-local local_reference = "local.reference"
-local local_scope = "local.scope"
-local local_definition = "local.definition"
-local local_statement = "local.statement"
-
 local M = {}
+
+M.local_reference = "local.reference"
+M.local_scope = "local.scope"
+M.local_definition = "local.definition"
+M.local_statement = "local.statement"
 
 local function get_named_children(node)
     local nodes = {} ---@type TSNode[]
@@ -211,30 +211,30 @@ M.get = memoize(function(bufnr)
 
         local scope = "local" ---@type string
         for k, v in pairs(metadata) do
-            if type(k) == "string" and vim.endswith(k, local_scope) then
+            if type(k) == "string" and vim.endswith(k, M.local_scope) then
                 scope = v
             end
         end
 
-        if node and vim.startswith(kind, local_definition) then
+        if node and vim.startswith(kind, M.local_definition) then
             table.insert(
                 definitions,
                 { kind = kind, node = node, scope = scope }
             )
         end
 
-        if node and kind == local_scope then
+        if node and kind == M.local_scope then
             table.insert(scopes, node)
         end
 
-        if node and kind == local_reference then
+        if node and kind == M.local_reference then
             table.insert(
                 references,
                 { kind = kind, node = node, scope = scope }
             )
         end
 
-        if node and kind == local_statement then
+        if node and kind == M.local_statement then
             table.insert(statements, node)
         end
     end
@@ -386,7 +386,7 @@ function M.find_usages(node, scope_node, bufnr)
         local kind = query.captures[id]
         if
             node_capture
-            and kind == local_reference
+            and kind == M.local_reference
             and ts.get_node_text(node_capture, bufnr) == node_text
             and M.find_definition(node_capture, bufnr):equal(definition)
             and not node_capture:equal(definition)

--- a/queries/php/locals.scm
+++ b/queries/php/locals.scm
@@ -4,4 +4,4 @@
 (expression_statement
   (assignment_expression
     (variable_name
-      (name) @definition.var))) 
+      (name) @local.definition.var))) 


### PR DESCRIPTION
BREAKING CHANGE: nvim-treesitter changed the format of local captures to follow the upstream format, we are doin the same.

Should fix #432 