### PR TITLE
feat(success_message): improve notification styling

### DIFF
--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -496,7 +496,7 @@ local function extract_setup(refactor)
             lsp_utils.replace_text(refactor.region, func_call)
         )
     end
-    refactor.success_message = ("[Refactor] Function extracted. Inlined %s funcion calls"):format(
+    refactor.success_message = ("Function extracted. Inlined %s function calls"):format(
         number_of_function_calls
     )
 

--- a/lua/refactoring/refactor/119.lua
+++ b/lua/refactoring/refactor/119.lua
@@ -113,7 +113,7 @@ local function extract_var_setup(refactor)
             )
         )
     end
-    refactor.success_message = ("[Refactor] Extracted %s variable occurrences"):format(
+    refactor.success_message = ("Extracted %s variable occurrences"):format(
         #actual_occurrences
     )
 

--- a/lua/refactoring/refactor/123.lua
+++ b/lua/refactoring/refactor/123.lua
@@ -170,7 +170,7 @@ local function get_inline_text_edits(
             ref = parent
         end
 
-        refactor.success_message = ("[Refactor] Inlined %d variable occurrences"):format(
+        refactor.success_message = ("Inlined %d variable occurrences"):format(
             #references
         )
 

--- a/lua/refactoring/tasks/post_refactor.lua
+++ b/lua/refactoring/tasks/post_refactor.lua
@@ -9,7 +9,11 @@ local M = {}
 local function success_message(refactor)
     local config = refactor.config:get()
     if refactor.success_message and config.show_success_message then
-        vim.notify(refactor.success_message, vim.log.levels.INFO)
+        vim.notify(
+            refactor.success_message,
+            vim.log.levels.INFO,
+            { title = "refactoring.nvim" }
+        )
     end
     return true, refactor
 end


### PR DESCRIPTION
This is a small PR that just improves the styling if the user has set `show_success_message = true`.

before:
![Pasted image 2024-02-17 at 09 44 34@2x](https://github.com/ThePrimeagen/refactoring.nvim/assets/73286100/0d29b6bd-0e36-4482-bf63-7bee753a201b)

after:
![Pasted image 2024-02-17 at 09 45 45@2x](https://github.com/ThePrimeagen/refactoring.nvim/assets/73286100/ce24888b-bee0-436e-9349-4b27871f7afb)
