### PR TITLE
Add return type when extracting to function in Python

### DIFF
--- a/lua/refactoring/code_generation/langs/python.lua
+++ b/lua/refactoring/code_generation/langs/python.lua
@@ -55,6 +55,9 @@ local function python_class_function_return(opts)
     if opts.func_header == nil then
         opts.func_header = ""
     end
+    if opts.return_type == nil then
+        opts.return_type = "None"
+    end
     return string.format(
         [[
 %sdef %s(self, %s) -> %s:

--- a/lua/refactoring/code_generation/langs/python.lua
+++ b/lua/refactoring/code_generation/langs/python.lua
@@ -50,6 +50,26 @@ local function python_class_function(opts)
     )
 end
 
+local function python_class_function_return(opts)
+    local args = build_args(opts.args, opts.args_types)
+    if opts.func_header == nil then
+        opts.func_header = ""
+    end
+    return string.format(
+        [[
+%sdef %s(self, %s) -> %s:
+%s
+
+
+]],
+        opts.func_header,
+        opts.name,
+        table.concat(args, ", "),
+        opts.return_type,
+        code_utils.stringify_code(opts.body)
+    )
+end
+
 local function python_constant(opts)
     local constant_string_pattern
 
@@ -99,7 +119,7 @@ local python = {
         return python_class_function(opts)
     end,
     class_function_return = function(opts)
-        return python_class_function(opts)
+        return python_class_function_return(opts)
     end,
     call_class_function = function(opts)
         return string.format(

--- a/lua/refactoring/code_generation/langs/python.lua
+++ b/lua/refactoring/code_generation/langs/python.lua
@@ -136,7 +136,7 @@ local python = {
         return python_function(opts)
     end,
     function_return = function(opts)
-        return python_class_function_return(opts)
+        return python_function_return(opts)
     end,
     call_function = function(opts)
         return string.format("%s(%s)", opts.name, table.concat(opts.args, ", "))

--- a/lua/refactoring/code_generation/langs/python.lua
+++ b/lua/refactoring/code_generation/langs/python.lua
@@ -31,6 +31,29 @@ local function python_function(opts)
     )
 end
 
+local function python_function_return(opts)
+    local args = build_args(opts.args, opts.args_types)
+    if opts.func_header == nil then
+        opts.func_header = ""
+    end
+    if opts.return_type == nil then
+        opts.return_type = "None"
+    end
+    return string.format(
+        [[
+%sdef %s(%s) -> %s:
+%s
+
+
+]],
+        opts.func_header,
+        opts.name,
+        table.concat(args, ", "),
+        opts.return_type,
+        code_utils.stringify_code(opts.body)
+    )
+end
+
 local function python_class_function(opts)
     local args = build_args(opts.args, opts.args_types)
     if opts.func_header == nil then
@@ -113,7 +136,7 @@ local python = {
         return python_function(opts)
     end,
     function_return = function(opts)
-        return python_function(opts)
+        return python_class_function_return(opts)
     end,
     call_function = function(opts)
         return string.format("%s(%s)", opts.name, table.concat(opts.args, ", "))

--- a/lua/refactoring/tests/refactor/106/py/class-return/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/class-return/extract.expected.py
@@ -1,6 +1,6 @@
 class Poggers:
 
-    def foo(self, a, test):
+    def foo(self, a, test) -> None:
         test_other = 11
         for x in range(test_other + test):
             print(x, a)

--- a/lua/refactoring/tests/refactor/106/py/multiple-returns/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/multiple-returns/extract.expected.py
@@ -1,5 +1,5 @@
 
-def extracted_func():
+def extracted_func() -> None:
     a = 1
     b = 1
     return a, b

--- a/lua/refactoring/tests/refactor/106/py/with-imports/extract.expected.py
+++ b/lua/refactoring/tests/refactor/106/py/with-imports/extract.expected.py
@@ -1,6 +1,6 @@
 import json
 
-def foo():
+def foo() -> None:
     bad_doc_ids = []
 
     with open("./some/path/full_bad.jsonl", 'r', encoding='utf-8') as f:


### PR DESCRIPTION
Currently if we have the following code:

```python
def main():
    x = 1
    y = 2

    z = x + y

    print(z)

```

The `Extract Function`, after providing the parameters and return type, generates the following code:

```python
def sum(x: int, y: int):
    z = x + y
    return z


def main():
    x = 1
    y = 2

    z = sum(x, y)

    print(z)
```

When it should be:

```python
def sum(x: int, y: int) -> int:
    z = x + y
    return z


def main():
    x = 1
    y = 2

    z = sum(x, y)

    print(z)
```

This pull request tries to fix it!

The changes are tested locally and it works ok.