### PR TITLE
Update python.lua

### DIFF
--- a/lua/refactoring/code_generation/langs/python.lua
+++ b/lua/refactoring/code_generation/langs/python.lua
@@ -164,7 +164,7 @@ local python = {
         return string.format("# %s", statement)
     end,
     default_printf_statement = function()
-        return { 'print(f"%s")' }
+        return { 'print("%s")' }
     end,
     print = function(opts)
         return string.format(opts.statement, opts.content)


### PR DESCRIPTION
this generates `f-string without any placeholders` and the linter marks this as a warning.