### PR TITLE
fix(106): return to initial window after creating new file

### DIFF
--- a/lua/refactoring/tasks/create_file.lua
+++ b/lua/refactoring/tasks/create_file.lua
@@ -10,18 +10,21 @@ function M.from_input(refactor)
         return false, "Error: Must provide a file name"
     end
 
-    local bufnr = vim.fn.bufnr(vim.fn.expand(file_name))
-    local winnr = vim.fn.bufwinnr(bufnr)
-    if winnr == -1 then
+    local starting_win = vim.api.nvim_get_current_win()
+
+    local new_bufnr = vim.fn.bufnr(vim.fn.expand(file_name))
+    local new_winnr = vim.fn.bufwinnr(new_bufnr)
+    if new_winnr == -1 then
         -- OPTIONS? We should probably configure this
         -- extract on second method added
         vim.cmd.vsplit(file_name)
         vim.opt_local.filetype = refactor.filetype
     else
-        vim.cmd.wincmd({ args = { "w" }, count = winnr })
+        vim.cmd.wincmd({ args = { "w" }, count = new_winnr })
     end
     table.insert(refactor.buffers, vim.api.nvim_get_current_buf())
 
+    vim.api.nvim_set_current_win(starting_win)
     return true, refactor
 end
 


### PR DESCRIPTION
This secures the assumption of other tasks that the user is in the window were the refactor started when they are executed

Fixes #474 (once more)