### PR TITLE
fix(lua-123): add filter to handle `{foo = foo}`

### DIFF
--- a/lua/refactoring/tasks/apply_text_edits.lua
+++ b/lua/refactoring/tasks/apply_text_edits.lua
@@ -77,10 +77,6 @@ local function refactor_apply_text_edits(refactor)
         if ns then
             preview_highlight(bufnr, ns, edit_set)
         end
-        if vim.fn.has("nvim-0.11") == 1 then
-            -- HACK: because of https://github.com/neovim/neovim/pull/29212
-            edit_set = vim.iter(edit_set):rev():totable()
-        end
         vim.lsp.util.apply_text_edits(edit_set, bufnr, "utf-16")
     end
 

--- a/lua/refactoring/treesitter/langs/lua.lua
+++ b/lua/refactoring/treesitter/langs/lua.lua
@@ -124,8 +124,14 @@ function Lua.new(bufnr, ft)
             if not parent then
                 return true
             end
+            -- foo.foo
+            -- ^
             if parent:type() == "dot_index_expression" then
                 return parent:field("table")[1] == node
+            -- {foo = foo}
+            --        ^
+            elseif parent:type() == "field" then
+                return parent:field("value")[1] == node
             end
             return true
         end,


### PR DESCRIPTION
Additional apply_text_edtits fix because of https://github.com/neovim/neovim/pull/29877