### PR TITLE
Lazy.nvim should be less lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ use {
       "nvim-lua/plenary.nvim",
       "nvim-treesitter/nvim-treesitter",
     },
+    lazy = false,
     config = function()
       require("refactoring").setup()
     end,


### PR DESCRIPTION
The :Refactor command doesn't work if the plugin isn't yet loaded.  Instead, load non-lazy.  Alternative would be to use `cmd = 'Refactor'`, but I haven't tested that.