### PR TITLE
fix(106): iter_matches backwards compatibility for nightly

### DIFF
--- a/lua/refactoring/refactor/106.lua
+++ b/lua/refactoring/refactor/106.lua
@@ -499,7 +499,14 @@ local function extract_setup(refactor)
         local body_sexpr = "(" .. table.concat(body_sexprs, " . ") .. ")"
         local query = vim.treesitter.query.parse(lang, body_sexpr)
 
-        for _, match in query:iter_matches(refactor.root, refactor.bufnr, 0, -1) do
+        local matches = query:iter_matches(
+            refactor.root,
+            refactor.bufnr,
+            0,
+            -1,
+            { all = false }
+        )
+        for _, match in matches do
             if match then
                 local first = match[1] --[[@as TSNode]]
                 local last = match[#match] --[[@as TSNode]]


### PR DESCRIPTION
Hello there!

Nightly has a breaking changes to `query:iter_matches` that broken 106 actions.
I tested this manually using the snippets in `tests/refactor/106/cpp` for normal and range actions in nightly.
From what I'm seeing in the gh actions logs, it seems to fix a couple of tests but not all that are currently failing in master.

Thanks!