### PR TITLE
feat: add useExCmd option to select_refactor()

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ vim.keymap.set(
 -- Note that not all refactor support both normal and visual mode
 ```
 
+`select_refactor()` uses `vim.ui.input` by default to input the arguments (if
+needed). If you want to use the Ex command to get the preview of the changes
+you can pass a second argument as `true` to the function.
+
+```lua
+require('refactoring').select_refactor({}, true)
+```
+
 #### Using Telescope<a name="config-refactoring-telescope"></a>
 
 If you would prefer to use Telescope to choose a refactor, you can do so

--- a/README.md
+++ b/README.md
@@ -268,10 +268,10 @@ vim.keymap.set(
 
 `select_refactor()` uses `vim.ui.input` by default to input the arguments (if
 needed). If you want to use the Ex command to get the preview of the changes
-you can pass a second argument as `true` to the function.
+you can use the `prefer_ex_cmd` option.
 
 ```lua
-require('refactoring').select_refactor({}, true)
+require('refactoring').select_refactor({prefer_ex_cmd = true})
 ```
 
 #### Using Telescope<a name="config-refactoring-telescope"></a>

--- a/lua/refactoring/init.lua
+++ b/lua/refactoring/init.lua
@@ -1,5 +1,10 @@
 local M = {}
 
+local _dont_need_args = {
+    "inline_var",
+    "inline_func",
+}
+
 ---@param config ConfigOpts
 function M.setup(config)
     require("refactoring.config").setup(config)
@@ -35,7 +40,8 @@ function M.get_refactors()
 end
 
 ---@param opts ConfigOpts
-function M.select_refactor(opts)
+---@param useExCmd? boolean
+function M.select_refactor(opts, useExCmd)
     -- vim.ui.select exits visual mode without setting the `<` and `>` marks
     local utils = require("refactoring.utils")
     if utils.is_visual_mode() then
@@ -49,7 +55,14 @@ function M.select_refactor(opts)
         )
 
         if selected_refactor then
-            M.refactor(selected_refactor, opts)
+            local refactors = require("refactoring.refactor")
+            local refactor = refactors.refactor_names[selected_refactor]
+                or refactors[selected_refactor] and selected_refactor
+            if not useExCmd or vim.list_contains(_dont_need_args, refactor) then
+                M.refactor(selected_refactor, opts)
+            else
+                vim.api.nvim_input(":Refactor " .. refactor .. " ")
+            end
         end
     end)()
 end


### PR DESCRIPTION
Added second boolean argument `useExCmd` to select_refactor to allow adding arguments to the Ex command and get the preview of changes.

Let me know any change you think appropiated.

Closes #491 