### PR TITLE
fix(debug): only use the location of the first non-blank character if it's greater than the cursor location

### DIFF
--- a/lua/refactoring/debug/debug_utils.lua
+++ b/lua/refactoring/debug/debug_utils.lua
@@ -29,10 +29,10 @@ function M.get_debug_points(refactor, opts)
         cursor.row,
         true
     )[1]
-    local _, non_white_space = current_line:find("^%s*()")
+    local _, non_white_space = current_line:find("^%s*()") --[[@as integer, integer]]
 
-    local range =
-        { cursor.row - 1, non_white_space, cursor.row - 1, non_white_space + 1 }
+    local cursor_col = math.max(non_white_space, cursor.col)
+    local range = { cursor.row - 1, cursor_col, cursor.row - 1, cursor_col + 1 }
     local language_tree = refactor.ts.language_tree:language_for_range(range)
 
     assert(language_tree)
@@ -80,7 +80,7 @@ function M.get_debug_points(refactor, opts)
                 start_row + 2,
                 true
             )[1]
-            _, non_white_space = below_line:find("^%s*()")
+            _, non_white_space = below_line:find("^%s*()") --[[@as integer, integer]]
 
             current = current:named_descendant_for_range(
                 start_row + 1,

--- a/lua/refactoring/debug/init.lua
+++ b/lua/refactoring/debug/init.lua
@@ -1,6 +1,6 @@
 local Config = require("refactoring.config")
 local printf = require("refactoring.debug.printf").printDebug
-local print_var = require("refactoring.debug.print_var").printDebug
+local print_var = require("refactoring.debug.print_var").print_debug
 local get_path = require("refactoring.debug.get_path")
 local cleanup = require("refactoring.debug.cleanup")
 

--- a/lua/refactoring/debug/print_var.lua
+++ b/lua/refactoring/debug/print_var.lua
@@ -48,7 +48,7 @@ end
 
 ---@param bufnr integer
 ---@param config Config
-function M.printDebug(bufnr, config)
+function M.print_debug(bufnr, config)
     Pipeline:from_task(refactor_setup(bufnr, config))
         :add_task(
             ---@param refactor Refactor

--- a/lua/refactoring/treesitter/langs/javascript.lua
+++ b/lua/refactoring/treesitter/langs/javascript.lua
@@ -37,6 +37,8 @@ function JavaScript.new(bufnr, ft)
             function_declaration = true,
             method_definition = true,
             arrow_function = true,
+            switch_statement = true,
+            switch_case = true,
             class_declaration = true,
         },
         valid_class_nodes = {
@@ -96,6 +98,8 @@ function JavaScript.new(bufnr, ft)
             InlineNode("(function_declaration) @tmp_capture"),
             InlineNode("(method_definition) @tmp_capture"),
             InlineNode("(arrow_function) @tmp_capture"),
+            InlineNode("(switch_statement) @tmp_capture"),
+            InlineNode("(switch_case) @tmp_capture"),
             InlineNode("(class_declaration) @tmp_capture"),
             InlineNode("(lexical_declaration) @tmp_capture"),
             InlineNode("(variable_declaration) @tmp_capture"),

--- a/lua/refactoring/treesitter/langs/javascript.lua
+++ b/lua/refactoring/treesitter/langs/javascript.lua
@@ -78,6 +78,7 @@ function JavaScript.new(bufnr, ft)
             arrow_function = function(node)
                 return FieldNode("name")(node:parent(), "(anon)")
             end,
+            function_expression = StringNode("(anon)"),
             if_statement = StringNode("if"),
             for_statement = StringNode("for"),
             for_in_statement = StringNode("for_in"),

--- a/lua/refactoring/treesitter/langs/typescript.lua
+++ b/lua/refactoring/treesitter/langs/typescript.lua
@@ -37,6 +37,8 @@ function Typescript.new(bufnr, ft)
             function_declaration = true,
             method_definition = true,
             arrow_function = true,
+            switch_statement = true,
+            switch_case = true,
             class_declaration = true,
         },
         valid_class_nodes = {
@@ -91,6 +93,8 @@ function Typescript.new(bufnr, ft)
             InlineNode("(function_declaration) @tmp_capture"),
             InlineNode("(method_definition) @tmp_capture"),
             InlineNode("(arrow_function) @tmp_capture"),
+            InlineNode("(switch_statement) @tmp_capture"),
+            InlineNode("(switch_case) @tmp_capture"),
             InlineNode("(lexical_declaration) @tmp_capture"),
         },
         ident_with_type = {

--- a/lua/refactoring/treesitter/langs/typescript.lua
+++ b/lua/refactoring/treesitter/langs/typescript.lua
@@ -73,6 +73,7 @@ function Typescript.new(bufnr, ft)
             arrow_function = function(node)
                 return FieldNode("name")(node:parent(), "(anon)")
             end,
+            function_expression = StringNode("(anon)"),
             if_statement = StringNode("if"),
             for_statement = StringNode("for"),
             for_in_statement = StringNode("for_in"),

--- a/lua/refactoring/treesitter/langs/typescriptreact.lua
+++ b/lua/refactoring/treesitter/langs/typescriptreact.lua
@@ -79,6 +79,7 @@ function TypescriptReact.new(bufnr, ft)
             arrow_function = function(node)
                 return FieldNode("name")(node:parent(), "(anon)")
             end,
+            function_expression = StringNode("(anon)"),
             if_statement = StringNode("if"),
             for_statement = StringNode("for"),
             for_in_statement = StringNode("for_in"),

--- a/lua/refactoring/treesitter/langs/typescriptreact.lua
+++ b/lua/refactoring/treesitter/langs/typescriptreact.lua
@@ -37,6 +37,8 @@ function TypescriptReact.new(bufnr, ft)
             function_declaration = true,
             method_definition = true,
             arrow_function = true,
+            switch_statement = true,
+            switch_case = true,
             class_declaration = true,
         },
         valid_class_nodes = {
@@ -97,6 +99,8 @@ function TypescriptReact.new(bufnr, ft)
             InlineNode("(function_declaration) @tmp_capture"),
             InlineNode("(method_definition) @tmp_capture"),
             InlineNode("(arrow_function) @tmp_capture"),
+            InlineNode("(switch_statement) @tmp_capture"),
+            InlineNode("(switch_case) @tmp_capture"),
             InlineNode("(lexical_declaration) @tmp_capture"),
         },
         ident_with_type = {


### PR DESCRIPTION
This also adds more statement and indent_scope nodes for js/ts/tsx