### PR TITLE
docs: Use opts field for lazy.nvim example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ use {
       "nvim-treesitter/nvim-treesitter",
     },
     lazy = false,
-    config = function()
-      require("refactoring").setup()
-    end,
+    opts = {},
   },
 ```
 


### PR DESCRIPTION
According to [lazy.nvim's documentation](https://lazy.folke.io/spec), it is recommended to use the `opts` field for configuring plugins, rather than providing a `config` function which calls the plugin's `setup` function:

> `config` is executed when the plugin loads. The default implementation will automatically run `require(MAIN).setup(opts)` if `opts` or `config = true` is set. Lazy uses several heuristics to determine the plugin's `MAIN` module automatically based on the plugin's **name**. _(`opts` is the recommended way to configure plugins)_.

This PR changes the README's example for installation with lazy.nvim to use the recommended `opts` field instead of the `config` one.