### PR TITLE
docs: Update printf pos opt to print_var

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ this:
 vim.keymap.set(
 	"n",
 	"<leader>rp",
-	function() require('refactoring').debug.printf({below = false}) end
+	function() require('refactoring').debug.print_var({below = true}) end
 )
 
 -- Print var


### PR DESCRIPTION
printf({below=true}) not only moves the print statment but changes it to the number 1, print_var does not