### PR TITLE
fix: preview flickering with folke/which-key.nvim

### DIFF
--- a/lua/refactoring/command.lua
+++ b/lua/refactoring/command.lua
@@ -59,7 +59,12 @@ local function command_preview(opts, ns)
     if keys == "g@" then
         keys = "gvg@"
     end
-    vim.cmd.normal(keys)
+    api.nvim_cmd({
+        cmd = "normal",
+        args = { keys },
+        bang = true,
+        mods = { noautocmd = true },
+    }, {})
 
     return PREVIEW_IN_CURRENT_BUFFER
 end
@@ -85,7 +90,12 @@ local function command(opts)
     if keys == "g@" then
         keys = "gvg@"
     end
-    vim.cmd.normal(keys)
+    api.nvim_cmd({
+        cmd = "normal",
+        args = { keys },
+        bang = true,
+        mods = { noautocmd = true },
+    }, {})
 end
 
 ---@param arg_lead string

--- a/lua/refactoring/command.lua
+++ b/lua/refactoring/command.lua
@@ -59,12 +59,7 @@ local function command_preview(opts, ns)
     if keys == "g@" then
         keys = "gvg@"
     end
-    api.nvim_cmd({
-        cmd = "normal",
-        args = { keys },
-        bang = true,
-        mods = { noautocmd = true },
-    }, {})
+    api.nvim_cmd({ cmd = "normal", args = { keys }, bang = true }, {})
 
     return PREVIEW_IN_CURRENT_BUFFER
 end
@@ -90,12 +85,7 @@ local function command(opts)
     if keys == "g@" then
         keys = "gvg@"
     end
-    api.nvim_cmd({
-        cmd = "normal",
-        args = { keys },
-        bang = true,
-        mods = { noautocmd = true },
-    }, {})
+    api.nvim_cmd({ cmd = "normal", args = { keys }, bang = true }, {})
 end
 
 ---@param arg_lead string


### PR DESCRIPTION
I came across a bug where the preview for the code to be inserted would alternately flicker on and off with each typed character of the variable/functions name. As shown in the screen recording:

https://github.com/user-attachments/assets/e8c41b2e-9770-45df-a1fa-d6da4365e0b9

It happens to me in a completely stock [LazyVim](https://www.lazyvim.org/) install with the only extra being the refactoring.nvim added via the Extras menu.

I spent a bit of time tracking down the cause by disabling plugins and found that it goes away when [which-key](https://github.com/folke/which-key.nvim) is disabled.

This patch changes the apply step from `vim.cmd.normal(keys)` to the typed API `api.nvim_cmd({ cmd = "normal", args = { keys }, bang = true, mods = { noautocmd = true } }, {})` in both the preview and execute paths. This prevents which-key (and probably other autocmd/mapping hooks that could interfere with it - I've only tested stock LazyVim) from firing which was causing the preview to flicker on alternating keystrokes.

Here is a screen recording with which-key re-enabled and the patch and the preview works as expected:

https://github.com/user-attachments/assets/308f47d7-dae1-455f-965c-b9bf57500154

I ran the linter, formatter, and test suite in the docker and everything passes, so I believe this PR is ready to review. Let me know if any other info would be helpful.
