### PR TITLE
feat: add dart language support

### DIFF
--- a/lua/refactoring/code_generation/init.lua
+++ b/lua/refactoring/code_generation/init.lua
@@ -14,7 +14,7 @@ local cs = require("refactoring.code_generation.langs.cs")
 local ruby = require("refactoring.code_generation.langs.ruby")
 local powershell = require("refactoring.code_generation.langs.powershell")
 local vimscript = require("refactoring.code_generation.langs.vimscript")
-
+local dart = require("refactoring.code_generation.langs.dart") 
 ---@type table<refactor.ft, refactor.CodeGeneration>|{new_line: fun(): string}
 local M = {
     javascript = javascript, -- includes jsx because they share parser
@@ -31,6 +31,7 @@ local M = {
     java = java,
     c_sharp = cs,
     ruby = ruby,
+    dart = dart,
     default = {},
 
     powershell = powershell,

--- a/lua/refactoring/code_generation/langs/dart.lua
+++ b/lua/refactoring/code_generation/langs/dart.lua
@@ -1,0 +1,84 @@
+local code_utils = require("refactoring.code_generation.utils")
+
+local function dart_function(opts)
+    local args = next(opts.args) and table.concat(opts.args, ", ") or ""
+
+    return ([[
+%s(%s) {
+%s
+}
+
+]]):format(opts.name, args, code_utils.stringify_code(opts.body))
+end
+
+local function dart_constant(opts)
+    local constant_string_pattern
+
+    if opts.multiple then
+        constant_string_pattern = ("var %s = %s;\n"):format(
+            table.concat(opts.identifiers, ", "),
+            table.concat(opts.values, ", ")
+        )
+    else
+        local name
+        if opts.name[1] ~= nil then
+            name = opts.name[1]
+        else
+            name = opts.name
+        end
+
+        if not opts.statement then
+            opts.statement = "var %s = %s;"
+        end
+
+        constant_string_pattern = (opts.statement .. "\n"):format(
+            name,
+            opts.value
+        )
+    end
+
+    return constant_string_pattern
+end
+
+---@type refactor.CodeGeneration
+local dart = {
+    comment = function(statement)
+        return ("// %s"):format(statement)
+    end,
+    constant = function(opts)
+        return dart_constant(opts)
+    end,
+    ["function"] = dart_function,
+    function_return = dart_function,
+    ["return"] = function(code)
+        return ("return %s;"):format(code_utils.stringify_code(code))
+    end,
+    call_function = function(opts)
+        return ("%s(%s)"):format(opts.name, table.concat(opts.args, ", "))
+    end,
+    class_function = dart_function,
+    class_function_return = dart_function,
+    call_class_function = function(opts)
+        return ("%s(%s)"):format(opts.name, table.concat(opts.args, ", "))
+    end,
+    terminate = function(code)
+        return code .. ";"
+    end,
+    pack = function(names)
+        return code_utils.returnify(names, "%s")
+    end,
+    print = function(opts)
+        return opts.statement:format(opts.content)
+    end,
+    default_printf_statement = function()
+        return { 'print("%s");' }
+    end,
+    default_print_var_statement = function()
+        return { 'print("%s ${%s}");' }
+    end,
+    print_var = function(opts)
+        return opts.statement:format(opts.prefix, opts.var)
+    end,
+}
+
+return dart

--- a/lua/refactoring/config/init.lua
+++ b/lua/refactoring/config/init.lua
@@ -73,6 +73,7 @@ local default_extract_var_statements = {}
 ---| "cxx"
 ---| "python"
 ---| "ruby"
+---| "dart"
 ---| "cs"
 
 ---@class refactor.ConfigOpts

--- a/lua/refactoring/treesitter/init.lua
+++ b/lua/refactoring/treesitter/init.lua
@@ -14,7 +14,7 @@ local cs = require("refactoring.treesitter.langs.cs")
 local ruby = require("refactoring.treesitter.langs.ruby")
 local powershell = require("refactoring.treesitter.langs.powershell")
 local vimscript = require("refactoring.treesitter.langs.vimscript")
-
+local dart = require("refactoring.treesitter.langs.dart")
 local api = vim.api
 local ts = vim.treesitter
 
@@ -35,6 +35,7 @@ local M = {
     java = java,
     c_sharp = cs,
     ruby = ruby,
+    dart = dart,
 
     cpp = cpp,
     c = c,

--- a/lua/refactoring/treesitter/langs/dart.lua
+++ b/lua/refactoring/treesitter/langs/dart.lua
@@ -1,0 +1,73 @@
+local TreeSitter = require("refactoring.treesitter.treesitter")
+local Nodes = require("refactoring.treesitter.nodes")
+local FieldNode = Nodes.FieldNode
+local InlineNode = Nodes.InlineNode
+
+---@class refactor.TreeSitterInstance
+local Dart = {}
+
+function Dart.new(bufnr, ft)
+    ---@type refactor.TreeSitterLanguageConfig
+    local config = {
+        filetype = ft,
+        bufnr = bufnr,
+        scope_names = {
+           function_signature = "function",
+           function_body = "function",
+           block = "function",
+        },
+        block_scope = {
+            function_signature = true,
+            function_body = true,
+            block = true,
+        },
+        indent_scopes = {
+            program = true,
+            ["if_statement"] = true,
+            ["for_statement"] = true,
+            ["while_statement"] = true,
+            function_signature = true,
+            method_signature = true,
+        },
+        variable_scope = {
+            local_variable_declaration = true,
+        },
+        local_var_names = {
+            InlineNode("(local_variable_declaration (initialized_variable_definition name: (identifier) @tmp_capture))"),
+        },
+        local_var_values = {
+            InlineNode("(local_variable_declaration (initialized_variable_definition value: (_) @tmp_capture))"),
+        },
+        local_declarations = {
+            InlineNode("((local_variable_declaration) @tmp_capture)"),
+        },
+       statements = {
+    InlineNode("(additive_expression) @tmp_capture"),
+    InlineNode("(multiplicative_expression) @tmp_capture"),
+    InlineNode("(return_statement) @tmp_capture"),
+    InlineNode("(if_statement) @tmp_capture"),
+    InlineNode("(for_statement) @tmp_capture"),
+    InlineNode("(while_statement) @tmp_capture"),
+    InlineNode("(local_variable_declaration) @tmp_capture"),
+    InlineNode("(expression_statement) @tmp_capture"),
+    InlineNode("(assignment_expression) @tmp_capture"),
+},
+        function_args = {
+            InlineNode("(formal_parameter_list (formal_parameter name: (identifier) @tmp_capture))"),
+        },
+        function_body = {
+            InlineNode("(function_body (_) @tmp_capture)"),
+        },
+        valid_class_nodes = {
+            class_definition = 1,
+        },
+        debug_paths = {
+            class_definition = FieldNode("name"),
+            function_signature = FieldNode("name"),
+            method_signature = FieldNode("name"),
+        },
+    }
+    return TreeSitter:new(config, bufnr)
+end
+
+return Dart


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, mostly additive language support and registrations; main risk is runtime errors if Dart Tree-sitter node/query shapes don’t match real parsers, impacting Dart users only.
> 
> **Overview**
> Adds **Dart language support** by registering `dart` in both the code-generation and Tree-sitter dispatch tables.
> 
> Introduces new Dart implementations for refactoring operations: `code_generation/langs/dart.lua` (function/constant/print/return helpers) and `treesitter/langs/dart.lua` (scope/indent/statement and local variable capture queries), and updates the config filetype union to include `"dart"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2509a21c7b7fd65edd1623ee78d7e180528ed66d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->