### PR TITLE
feat: enable command preview on async refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Tree-sitter and LSP powered refactoring
 
 - Provides refactoring and print-debugging operators (see `:h operator`) powered by LSP and tree-sitter.
-- Supports dot-repeat and any textobject.
+- Supports dot-repeat and any textobject/motion.
 - Allows fine-grained customization while providing reasonable defaults.
 
 More details on [Features](#features)
@@ -98,6 +98,8 @@ The default configuration can be found at [./lua/refactoring/config.lua](./lua/r
 - globally: `require("refactoring").setup({...})`
 - for a single call: `require("refactoring").inline_var({...})`
 - for a given buffer: `vim.b.refactor_config = {...}`
+
+### Keymaps
 
 No keymaps are created by default. These are the suggested keymaps:
 
@@ -197,8 +199,9 @@ end, { desc = "Select refactor" })
 
 </details>
 
-> [!NOTE]
-> The `:Refactor` command can be used instead of keymaps, its biggest selling point is the live previewing of changes. However, live previewing user commands doesn't seem to play nicely with async functions, so it is disabled for all [Features](#Features) that rely on LSP.
+### User commands
+
+The `:Refactor` command can be used to run any refactor. It supports previewing changes and offers completions for available refactors. For refactors that require additional input, extra arguments to the `:Refactor` command will be used as input.
 
 ## Supported languages
 

--- a/doc/refactoring.txt
+++ b/doc/refactoring.txt
@@ -138,6 +138,10 @@ Fields ~
                                                            *M.select_refactor()*
                           `M.select_refactor`({opts})
 Use |vim.ui.select()| to select a refactor.
+
+The `prefer_ex_cmd` option can be used to pre-populate the command line
+with the ex command needed to execute the refactor. This allows to previews
+changes.
 Parameters ~
 {opts?} (`refactor.select_refactor.Opts`)
 

--- a/lua/refactoring.lua
+++ b/lua/refactoring.lua
@@ -187,6 +187,10 @@ end
 ---@field prefer_ex_cmd boolean?
 
 --- Use |vim.ui.select()| to select a refactor.
+---
+--- The `prefer_ex_cmd` option can be used to pre-populate the command line
+--- with the ex command needed to execute the refactor. This allows to previews
+--- changes.
 ---@param opts? refactor.select_refactor.Opts
 function M.select_refactor(opts)
   local prefer_ex_cmd = opts and opts.prefer_ex_cmd or false

--- a/lua/refactoring/command.lua
+++ b/lua/refactoring/command.lua
@@ -45,23 +45,25 @@ local function preview(opts, ns)
   -- TODO: `:h command-preview` seems to be broken with async code (it doesn't
   -- show async updates to buffers and may crash Neovim (when modiying buffers
   -- with outdated information?)). Look more into it and open an issue upstream
-  -- if refactor == "inline_var" then vim.cmd.normal(require("refactoring").inline_var(refactor_opts)) end
+  if refactor == "inline_var" then vim.cmd.normal(require("refactoring").inline_var(refactor_opts)) end
   if refactor == "extract_var" then vim.cmd.normal("gv" .. require("refactoring").extract_var(refactor_opts)) end
-  -- if refactor == "inline_func" then vim.cmd.normal(require("refactoring").inline_func(refactor_opts)) end
+  if refactor == "inline_func" then vim.cmd.normal(require("refactoring").inline_func(refactor_opts)) end
   if refactor == "extract_func" then vim.cmd.normal("gv" .. require("refactoring").extract_func(refactor_opts)) end
   if refactor == "extract_func_to_file" then
     vim.cmd.normal("gv" .. require("refactoring").extract_func_to_file(refactor_opts))
   end
 
   if
-    -- refactor == "inline_var" or
-    refactor == "extract_var"
-    -- or refactor == "inline_func"
+    refactor == "inline_var"
+    or refactor == "extract_var"
+    or refactor == "inline_func"
     or refactor == "extract_func"
     or refactor == "extract_func_to_file"
   then
     return PREVIEW_IN_CURRENT_BUFFER
   end
+
+  return DO_NOT_PREVIEW
 end
 
 ---@param arg_lead string

--- a/lua/refactoring/refactor/extract_func.lua
+++ b/lua/refactoring/refactor/extract_func.lua
@@ -705,6 +705,7 @@ M.extract_func = function(range_type, config)
     }
   end)
   task:raise_on_error()
+  if opts.preview_ns then task:wait() end
 end
 
 ---@param range_type 'v' | 'V' | ''
@@ -746,6 +747,7 @@ M.extract_func_to_file = function(range_type, config)
     }
   end)
   task:raise_on_error()
+  if opts.preview_ns then task:wait() end
 end
 
 return M

--- a/lua/refactoring/refactor/extract_var.lua
+++ b/lua/refactoring/refactor/extract_var.lua
@@ -276,6 +276,7 @@ function M.extract_var(range_type, config)
   end)
 
   task:raise_on_error()
+  if opts.preview_ns then task:wait() end
 end
 
 return M

--- a/lua/refactoring/refactor/inline_func.lua
+++ b/lua/refactoring/refactor/inline_func.lua
@@ -423,6 +423,7 @@ function M.inline_func(_, config)
     apply_text_edits(text_edits_by_buf)
   end)
   task:raise_on_error()
+  if opts.preview_ns then task:wait() end
 end
 
 return M

--- a/lua/refactoring/refactor/inline_var.lua
+++ b/lua/refactoring/refactor/inline_var.lua
@@ -355,6 +355,7 @@ function M.inline_var(_, config)
     apply_text_edits(text_edits_by_buf)
   end)
   task:raise_on_error()
+  if opts.preview_ns then task:wait() end
 end
 
 return M


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables command-line previewing for previously async-only refactors by changing execution/waiting behavior; this could impact UI responsiveness or introduce edge-case buffer update issues during previews.
> 
> **Overview**
> Adds proper `:Refactor` command preview support for async refactors by running `inline_var`/`inline_func` during preview and making async refactor tasks block (`task:wait()`) when `preview_ns` is set.
> 
> Updates `select_refactor` docs/API with a `prefer_ex_cmd` option to prefill the `:Refactor …` ex command for preview workflows, and refreshes README guidance around motions and user commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8fc9e08abe0afc7894b500c35c880f834b0cf39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->