### PR TITLE
feat(debug): add C++ support

### DIFF
--- a/lua/refactoring/config.lua
+++ b/lua/refactoring/config.lua
@@ -785,6 +785,14 @@ local print_var_code_generation = {
         opts.identifier
       )
     end,
+    cpp = function(opts)
+      return ([[std::cout << "%s %s %s: " << %s << "\n";]]):format(
+        opts.debug_path,
+        opts.identifier_str,
+        opts.count,
+        opts.identifier
+      )
+    end,
     javascript = function(opts)
       return ([[console.log("%s %s %s:", %s)]]):format(
         opts.debug_path:gsub('"', '\\"'),
@@ -825,7 +833,6 @@ local print_var_code_generation = {
     end,
   },
 }
-print_var_code_generation.print_var.cpp = print_var_code_generation.print_var.c
 print_var_code_generation.print_var.typescript = print_var_code_generation.print_var.javascript
 print_var_code_generation.print_var.tsx = print_var_code_generation.print_var.javascript
 
@@ -837,6 +844,9 @@ local print_loc_code_generation = {
     end,
     c = function(opts)
       return ([[printf("%s %s\n");]]):format(opts.debug_path, opts.count)
+    end,
+    cpp = function(opts)
+      return ([[std::cout << "%s %s\n";]]):format(opts.debug_path, opts.count)
     end,
     javascript = function(opts)
       return ([[console.log("%s %s")]]):format(opts.debug_path, opts.count)
@@ -875,6 +885,14 @@ local print_exp_code_generation = {
     end,
     c = function(opts)
       return ([[printf("%s %s %s: %%s \n", %s);]]):format(
+        opts.debug_path,
+        opts.expression_str,
+        opts.count,
+        opts.expression
+      )
+    end,
+    cpp = function(opts)
+      return ([[std::cout << "%s %s %s: " << %s << "\n";]]):format(
         opts.debug_path,
         opts.expression_str,
         opts.count,

--- a/queries/cpp/refactor_debug_path.scm
+++ b/queries/cpp/refactor_debug_path.scm
@@ -1,0 +1,1 @@
+; inherits: c

--- a/tests/files/print_var_works_after.cpp
+++ b/tests/files/print_var_works_after.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main() {
+  int i = 3;
+  // __PRINT_VAR_START
+  std::cout << "┆main┆ ╎i╎ ┊1┊: " << i << "\n";// __PRINT_VAR_END
+  return i;
+}

--- a/tests/files/print_var_works_before.cpp
+++ b/tests/files/print_var_works_before.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+  int i = 3;
+  return i;
+}

--- a/tests/test_print_var.lua
+++ b/tests/test_print_var.lua
@@ -103,6 +103,26 @@ T["c"]["works"] = function()
   validate(lines, { 4, 6 }, expected_lines, " pviw")
 end
 
+T["cpp"] = MiniTest.new_set {
+  hooks = {
+    pre_case = function()
+      child.lua [[
+vim.api.nvim_create_autocmd('Filetype', {
+  pattern = 'cpp',
+  command = 'setlocal expandtab shiftwidth=2'
+})
+]]
+    end,
+  },
+}
+
+T["cpp"]["works"] = function()
+  local lines = read_file "./tests/files/print_var_works_before.cpp"
+  local expected_lines = read_file "./tests/files/print_var_works_after.cpp"
+  child.cmd "edit tmp.cpp"
+  validate(lines, { 4, 6 }, expected_lines, " pviw")
+end
+
 T["javascript"] = MiniTest.new_set {
   hooks = {
     pre_case = function()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are additive and limited to C++ code generation/query fixtures, with minimal impact on existing languages aside from selecting the new `cpp` generator where applicable.
> 
> **Overview**
> Adds **C++ support** for debug refactoring helpers by introducing `cpp` code generators for `print_var`, `print_loc`, and `print_exp` that emit `std::cout` statements.
> 
> Includes a new `queries/cpp/refactor_debug_path.scm` (inheriting from `c`) and extends the test suite with C++ fixtures plus a `tmp.cpp` `print_var` integration test to verify the inserted output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f6c11be31ccd47051c8a9094c110afccf1644a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->