### PR TITLE
fix(python): inline var comparison operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ deps:
 	git clone --filter=blob:none https://github.com/lewis6991/async.nvim deps/async.nvim
 	git clone --filter=blob:none https://github.com/mason-org/mason.nvim deps/mason.nvim
 	git clone --branch main --filter=blob:none https://github.com/nvim-treesitter/nvim-treesitter deps/nvim-treesitter
-	nvim --headless --clean -u scripts/minimal_init.lua -c "MasonInstall lua-language-server clangd" -c qall
+	nvim --headless --clean -u scripts/minimal_init.lua -c "MasonInstall lua-language-server clangd pyright" -c qall
 	nvim --headless --clean -u scripts/minimal_init.lua -l deps/nvim-treesitter/scripts/install-parsers.lua lua java php go powershell c c_sharp cpp javascript python ruby tsx vim markdown
 
 docs:

--- a/queries/python/refactor_reference.scm
+++ b/queries/python/refactor_reference.scm
@@ -28,6 +28,10 @@
   (identifier) @reference.identifier
   (#set! reference_type read))
 
+(comparison_operator
+  (identifier) @reference.identifier
+  (#set! reference_type read))
+
 (for_statement
   left: (identifier) @reference.identifier
   (#set! reference_type write)

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -50,7 +50,14 @@ vim.lsp.config("clangd", {
     if init_result.offsetEncoding then client.offset_encoding = init_result.offsetEncoding end
   end,
 })
-vim.lsp.enable { "lua_ls", "clangd" }
+vim.lsp.config("pyright", {
+  cmd = { "pyright-langserver", "--stdio" },
+  filetypes = { "python" },
+  root_markers = {
+    ".git",
+  },
+})
+vim.lsp.enable { "lua_ls", "clangd", "pyright" }
 
 vim.g.mapleader = " "
 vim.keymap.set("n", "<leader>ai", function()

--- a/tests/files/inline_var_comparison_operator_after.py
+++ b/tests/files/inline_var_comparison_operator_after.py
@@ -1,0 +1,5 @@
+def is_foo(a: int, b: int) -> None:
+    if (a + b) > 10:
+        print("Is foo")
+    else:
+        print("Is not foo")

--- a/tests/files/inline_var_comparison_operator_before.py
+++ b/tests/files/inline_var_comparison_operator_before.py
@@ -1,0 +1,6 @@
+def is_foo(a: int, b: int) -> None:
+    my_sum = a + b
+    if my_sum > 10:
+        print("Is foo")
+    else:
+        print("Is not foo")

--- a/tests/test_inline_var.lua
+++ b/tests/test_inline_var.lua
@@ -132,4 +132,25 @@ T["c"]["multiple assignment"] = function()
   validate(lines, { 4, 8 }, expected_lines)
 end
 
+T["python"] = MiniTest.new_set {
+  hooks = {
+    pre_case = function()
+      child.lua [[
+vim.api.nvim_create_autocmd('Filetype', {
+  pattern = 'python',
+  command = 'setlocal expandtab shiftwidth=4'
+})
+]]
+    end,
+  },
+}
+
+T["python"]["comparison operator"] = function()
+  local lines = read_file "./tests/files/inline_var_comparison_operator_before.py"
+  local expected_lines = read_file "./tests/files/inline_var_comparison_operator_after.py"
+
+  child.cmd "edit tmp.py"
+  validate(lines, { 2, 4 }, expected_lines)
+end
+
 return T


### PR DESCRIPTION
## Summary

I couldn't inline a variable when it's next to a comparison operator.
This PR captures the bug and fixes it.